### PR TITLE
Provide a default --to flag for clients, use --id for identifier

### DIFF
--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -71,7 +71,7 @@ func main() {
 
 		LimitBytes:         500 * 1024,
 		TokenExpireSeconds: 24 * 60 * 60,
-		PartitionKey:       "cluster",
+		PartitionKey:       "_id",
 	}
 	cmd := &cobra.Command{
 		Short:        "Aggregate federated metrics pushes",

--- a/pkg/authorizer/server/server.go
+++ b/pkg/authorizer/server/server.go
@@ -59,9 +59,10 @@ func (a *Authorizer) AuthorizeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	cluster := req.Form.Get(a.partitionKey)
+	uniqueIdKey := "id"
+	cluster := req.Form.Get(uniqueIdKey)
 	if len(cluster) == 0 {
-		http.Error(w, fmt.Sprintf("The '%s' parameter must be specified via URL or url-encoded form body", a.partitionKey), http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("The '%s' parameter must be specified via URL or url-encoded form body", uniqueIdKey), http.StatusBadRequest)
 		return
 	}
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -39,8 +39,8 @@ trap 'kill $(jobs -p); exit 0' EXIT
   sleep 5
   exec ./telemeter-client \
     --from "${server}" --from-token "${token}" \
-    --to "http://localhost:9003/upload" \
-    --to-auth "http://localhost:9003/authorize?cluster=b" \
+    --to "http://localhost:9003" \
+    --id "test" \
     --to-token a \
     --interval 30s \
     --anonymize-labels "instance" --anonymize-salt "a-unique-value" \
@@ -64,7 +64,7 @@ if [[ -n "${test-}" ]]; then
       echo "error: Did not successfully retrieve cluster metrics from the local Prometheus server" 1>&2
       exit 1
     fi
-    if [[ "$( curl http://localhost:9005/api/v1/query --data-urlencode 'query=count({cluster="b"})' -G 2>/dev/null | python -c 'import sys, json; print json.load(sys.stdin)["data"]["result"][0]["value"][1]' 2>/dev/null )" -eq 0 ]]; then
+    if [[ "$( curl http://localhost:9005/api/v1/query --data-urlencode 'query=count({_id="test"})' -G 2>/dev/null | python -c 'import sys, json; print json.load(sys.stdin)["data"]["result"][0]["value"][1]' 2>/dev/null )" -eq 0 ]]; then
       retries=$((retries-1))
       sleep 1
       continue


### PR DESCRIPTION
Switch authentication from using `?cluster=` to `?id=`, and set the
default partition key to `_id` to avoid conflicts with user provided
labels.