### PR TITLE
Never return samples older than 10 minutes from the federation endpoint

### DIFF
--- a/cmd/telemeter-server/main_test.go
+++ b/cmd/telemeter-server/main_test.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/openshift/telemeter/pkg/untrusted"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/openshift/telemeter/pkg/untrusted"
 
 	clientmodel "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
@@ -85,7 +86,7 @@ func testPost(t *testing.T, validator server.UploadValidator, send, expect []*cl
 	mustPost(s.URL, expfmt.FmtProtoDelim, send)
 
 	var actual []*clientmodel.MetricFamily
-	err := store.ReadMetrics(context.Background(), func(partitionKey string, families []*clientmodel.MetricFamily) error {
+	err := store.ReadMetrics(context.Background(), 0, func(partitionKey string, families []*clientmodel.MetricFamily) error {
 		if partitionKey != "test" {
 			t.Fatalf("unexpected partition key: %s", partitionKey)
 		}
@@ -103,7 +104,7 @@ func testPost(t *testing.T, validator server.UploadValidator, send, expect []*cl
 func TestGet(t *testing.T) {
 	store := server.NewMemoryStore()
 	validator := untrusted.NewValidator("cluster", nil, 0, 0)
-	server := server.New(store, validator)
+	server := server.NewNonExpiring(store, validator)
 	s := httptest.NewServer(http.HandlerFunc(server.Get))
 	defer s.Close()
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -42,7 +42,7 @@ type metricMessageHeader struct {
 }
 
 type LocalStore interface {
-	ReadMetrics(ctx context.Context, fn func(partitionKey string, families []*clientmodel.MetricFamily) error) error
+	ReadMetrics(ctx context.Context, minTimestampMs int64, fn func(partitionKey string, families []*clientmodel.MetricFamily) error) error
 	WriteMetrics(ctx context.Context, partitionKey string, families []*clientmodel.MetricFamily) error
 }
 
@@ -357,8 +357,8 @@ func (c *DynamicCluster) forwardMetrics(ctx context.Context, partitionKey string
 	return true, nil
 }
 
-func (c *DynamicCluster) ReadMetrics(ctx context.Context, fn func(partitionKey string, families []*clientmodel.MetricFamily) error) error {
-	return c.store.ReadMetrics(ctx, fn)
+func (c *DynamicCluster) ReadMetrics(ctx context.Context, minTimestampMs int64, fn func(partitionKey string, families []*clientmodel.MetricFamily) error) error {
+	return c.store.ReadMetrics(ctx, minTimestampMs, fn)
 }
 
 func (c *DynamicCluster) WriteMetrics(ctx context.Context, partitionKey string, families []*clientmodel.MetricFamily) error {

--- a/pkg/http/server/memstore.go
+++ b/pkg/http/server/memstore.go
@@ -22,7 +22,7 @@ func NewMemoryStore() Store {
 	}
 }
 
-func (s *memoryStore) ReadMetrics(ctx context.Context, fn func(partitionKey string, families []*clientmodel.MetricFamily) error) error {
+func (s *memoryStore) ReadMetrics(ctx context.Context, minTimestampMs int64, fn func(partitionKey string, families []*clientmodel.MetricFamily) error) error {
 	s.lock.Lock()
 	store := s.store
 	s.store = make(map[string]*clusterMetricSlice)

--- a/pkg/http/server/server_test.go
+++ b/pkg/http/server/server_test.go
@@ -1,0 +1,119 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	clientmodel "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+func family(name string, timestamps ...int64) *clientmodel.MetricFamily {
+	families := &clientmodel.MetricFamily{Name: &name}
+	for i := range timestamps {
+		one := float64(1)
+		families.Metric = append(families.Metric, &clientmodel.Metric{Counter: &clientmodel.Counter{Value: &one}, TimestampMs: &timestamps[i]})
+	}
+	return families
+}
+
+func metric(timestamp int64) *clientmodel.Metric {
+	return &clientmodel.Metric{
+		TimestampMs: &timestamp,
+	}
+}
+
+func storeWithData(data map[string][]*clientmodel.MetricFamily) Store {
+	s := NewMemoryStore()
+	for k, v := range data {
+		s.WriteMetrics(context.TODO(), k, v)
+	}
+	return s
+}
+
+func TestServer_Get(t *testing.T) {
+	type fields struct {
+		store     Store
+		validator UploadValidator
+		nowFn     func() time.Time
+	}
+	tests := []struct {
+		name         string
+		fields       fields
+		req          *http.Request
+		wantCode     int
+		wantFamilies []*clientmodel.MetricFamily
+	}{
+		{
+			name: "drop expired samples",
+			fields: fields{
+				store: storeWithData(map[string][]*clientmodel.MetricFamily{
+					"cluster-1": {
+						family("test_1", 1000000, 1002000, 1004000),
+						family("test_2", 1000000, 1002000, 1004000),
+					},
+				}),
+				nowFn: func() time.Time { return time.Unix(1001+10*60, 0) },
+			},
+			req: &http.Request{
+				Method: "GET",
+			},
+			wantFamilies: []*clientmodel.MetricFamily{
+				family("test_1", 1002000, 1004000),
+				family("test_2", 1002000, 1004000),
+			},
+			wantCode: 200,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{
+				store:     tt.fields.store,
+				validator: tt.fields.validator,
+				nowFn:     tt.fields.nowFn,
+			}
+			w := httptest.NewRecorder()
+			s.Get(w, tt.req)
+			if w.Code != tt.wantCode {
+				t.Fatalf("unexpected code %d", w.Code)
+			}
+			families, err := read(w.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, expected := familiesToText(families), familiesToText(tt.wantFamilies)
+			if got != expected {
+				t.Fatalf("unexpected result\n%s\n%s", got, expected)
+			}
+		})
+	}
+}
+
+func familiesToText(families []*clientmodel.MetricFamily) string {
+	buf := &bytes.Buffer{}
+	for _, f := range families {
+		expfmt.MetricFamilyToText(buf, f)
+	}
+	return buf.String()
+}
+
+func read(r io.Reader) ([]*clientmodel.MetricFamily, error) {
+	decoder := expfmt.NewDecoder(r, expfmt.FmtText)
+	families := make([]*clientmodel.MetricFamily, 0, 100)
+	for {
+		family := &clientmodel.MetricFamily{}
+		if err := decoder.Decode(family); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		families = append(families, family)
+	}
+	return families, nil
+}

--- a/pkg/transform/transform_test.go
+++ b/pkg/transform/transform_test.go
@@ -18,6 +18,12 @@ func family(name string, timestamps ...int64) *clientmodel.MetricFamily {
 	return families
 }
 
+func metric(timestamp int64) *clientmodel.Metric {
+	return &clientmodel.Metric{
+		TimestampMs: &timestamp,
+	}
+}
+
 func TestPack(t *testing.T) {
 	a := family("A", 0)
 	b := family("B", 1)
@@ -40,6 +46,49 @@ func TestPack(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := Pack(tt.args); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Pack() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPackMetrics(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    *clientmodel.MetricFamily
+		want    *clientmodel.MetricFamily
+		wantOk  bool
+		wantErr bool
+	}{
+		{name: "empty", args: &clientmodel.MetricFamily{}, want: &clientmodel.MetricFamily{}},
+		{
+			name: "all nil",
+			args: &clientmodel.MetricFamily{Metric: []*clientmodel.Metric{nil, nil}},
+			want: &clientmodel.MetricFamily{Metric: []*clientmodel.Metric{}},
+		},
+		{
+			name:   "leading nil",
+			args:   &clientmodel.MetricFamily{Metric: []*clientmodel.Metric{nil, metric(1)}},
+			want:   &clientmodel.MetricFamily{Metric: []*clientmodel.Metric{metric(1)}},
+			wantOk: true,
+		},
+		{
+			name:   "trailing nil",
+			args:   &clientmodel.MetricFamily{Metric: []*clientmodel.Metric{metric(1), nil}},
+			want:   &clientmodel.MetricFamily{Metric: []*clientmodel.Metric{metric(1)}},
+			wantOk: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := PackMetrics.Transform(tt.args)
+			if got != tt.wantOk {
+				t.Errorf("PackMetrics() = %t, want %t", got, tt.wantOk)
+			}
+			if (gotErr != nil) != tt.wantErr {
+				t.Errorf("PackMetrics() = %v, want %t", gotErr, tt.wantErr)
+			}
+			if !reflect.DeepEqual(tt.args, tt.want) {
+				t.Errorf("PackMetrics() = %v, want %v", tt.args, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Prevent very old samples from remaining in the store even after the service stops reporting in.