### PR TITLE
Capture alerts but rename them before sending

### DIFF
--- a/deploy/default-rules
+++ b/deploy/default-rules
@@ -3,3 +3,4 @@
 {__name__="machine_cpu_cores"}
 {__name__="machine_memory_bytes"}
 {__name__="etcd_object_counts"}
+{__name__="ALERTS",alertstate="firing"}

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -406,6 +406,20 @@ Found:
 	return len(family.Metric) > 0, nil
 }
 
+type RenameMetrics struct {
+	Names map[string]string
+}
+
+func (m RenameMetrics) Transform(family *clientmodel.MetricFamily) (bool, error) {
+	if family == nil || family.Name == nil {
+		return true, nil
+	}
+	if replace, ok := m.Names[*family.Name]; ok {
+		family.Name = &replace
+	}
+	return true, nil
+}
+
 var SortMetrics = sortMetrics{}
 
 type sortMetrics struct{}


### PR DESCRIPTION
Prometheus treats `ALERTS` as a special series, but that data may be something to gather for historical purposes. Support `--rename` with a default value of `ALERTS=alerts`, add it to default-rules, and add an integration test.