### PR TITLE
pkg/metricsclient: disable keep alives

### DIFF
--- a/pkg/metricsclient/metricsclient.go
+++ b/pkg/metricsclient/metricsclient.go
@@ -226,5 +226,6 @@ func DefaultTransport() *http.Transport {
 			KeepAlive: 30 * time.Second,
 		}).Dial,
 		TLSHandshakeTimeout: 10 * time.Second,
+		DisableKeepAlives:   true,
 	}
 }


### PR DESCRIPTION
Currently, telemeter-client leaves the connection open between subsequent pushes.
This quickly exhausts file descriptors on server-side.

As telemeter client metric pushes are far apart (4.5 minutes), it doesn't make sense
to enable this setting on the client.

/cc @squat @brancz: This was the cause for yesterday's benchmark failures.
The server-side probably had a too low open files ulimit, causing new connections to be rejected.
With this tweak, I can launch 10000 local mock clients easily and send metrics consistently.