### PR TITLE
jsonnet: put telemeter server URL into secret and env var

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter/client"
                 }
             },
-            "version": " 2a3478155bc786cbedc2266786d0c2901c7f2119"
+            "version": "741c6be8b66a5de625adf21da52b1cd0a380bdd2"
         },
         {
             "name": "ksonnet",

--- a/manifests/telemeter-client-deployment.yaml
+++ b/manifests/telemeter-client-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - --from=https://prometheus-k8s.openshift-monitoring.svc:9091
         - --from-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
         - --from-token-file=/var/run/secrets/kubernetes.io/serviceaccount/token
-        - --to=
+        - --to=$(TO)
         - --to-token-file=/etc/telemeter/token
         - --listen=localhost:8080
         env:
@@ -30,6 +30,11 @@ spec:
           valueFrom:
             secretKeyRef:
               key: id
+              name: telemeter-client
+        - name: TO
+          valueFrom:
+            secretKeyRef:
+              key: to
               name: telemeter-client
         image: openshift/telemeter:v3.11
         name: telemeter-client

--- a/manifests/telemeter-client-secret.yaml
+++ b/manifests/telemeter-client-secret.yaml
@@ -1,5 +1,6 @@
 apiVersion: v1
-data: {}
+data:
+  to: ""
 kind: Secret
 metadata:
   labels:


### PR DESCRIPTION
This PR puts the telemeter server URL into a secret and loads it into the container using an environment variable. This has the benefit of being easier to override in actual deployments by simple modifying the underlying secret rather than needing to iterate over the flags and modifying the one with the URL.

This helps address: https://github.com/openshift/cluster-monitoring-operator/pull/103#discussion_r220598831

cc @s-urbaniak @brancz 