### PR TITLE
jsonnet: extend jobs with telemeter client

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter/client"
                 }
             },
-            "version": "741c6be8b66a5de625adf21da52b1cd0a380bdd2"
+            "version": "0f4395ca74baf07da2cab1fd386ee29300235d1a"
         },
         {
             "name": "ksonnet",

--- a/jsonnet/telemeter/client/telemeter-client.libsonnet
+++ b/jsonnet/telemeter/client/telemeter-client.libsonnet
@@ -1,6 +1,6 @@
 (import 'kubernetes/kubernetes.libsonnet') + {
   _config+:: {
-    jobs: {
+    jobs+: {
       TelemeterClient: 'job="telemeter-client"',
     },
   },


### PR DESCRIPTION
This PR corrects an issue where the jobs field in the config was being overwritten rather than extended.

addresses: https://github.com/openshift/cluster-monitoring-operator/pull/103#discussion_r220684050

cc @brancz @s-urbaniak 