### PR TITLE
jsonnet: telemeter-client fixes 

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter/client"
                 }
             },
-            "version": "0f4395ca74baf07da2cab1fd386ee29300235d1a"
+            "version": "e42df32b074384e8c0f256dceb7a7ce1c8329b1e"
         },
         {
             "name": "ksonnet",

--- a/jsonnet/telemeter/client/kubernetes/kubernetes.libsonnet
+++ b/jsonnet/telemeter/client/kubernetes/kubernetes.libsonnet
@@ -16,11 +16,11 @@ local metricsPort = 8080;
     },
 
     versions+:: {
-      telemeterClient: 'v3.11',
+      telemeterClient: 'v4.0',
     },
 
     imageRepos+:: {
-      telemeterClient: 'openshift/telemeter',
+      telemeterClient: 'quay.io/openshift/origin-telemeter',
     },
   },
 
@@ -59,9 +59,6 @@ local metricsPort = 8080;
       deployment.mixin.metadata.withNamespace($._config.namespace) +
       deployment.mixin.metadata.withLabels(podLabels) +
       deployment.mixin.spec.selector.withMatchLabels(podLabels) +
-      deployment.mixin.spec.template.spec.securityContext.withRunAsNonRoot(true) +
-      deployment.mixin.spec.template.spec.securityContext.withRunAsUser(65534) +
-      deployment.mixin.spec.template.spec.withServiceAccountName('telemeter-client') +
       deployment.mixin.spec.template.spec.withVolumes([credentialsVolume]),
 
     secret:

--- a/manifests/telemeter-client-deployment.yaml
+++ b/manifests/telemeter-client-deployment.yaml
@@ -36,7 +36,7 @@ spec:
             secretKeyRef:
               key: to
               name: telemeter-client
-        image: openshift/telemeter:v3.11
+        image: quay.io/openshift/origin-telemeter:v4.0
         name: telemeter-client
         ports:
         - containerPort: 8080
@@ -45,10 +45,6 @@ spec:
         - mountPath: /etc/telemeter
           name: credentials
           readOnly: false
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-      serviceAccountName: telemeter-client
       volumes:
       - name: credentials
         secret:


### PR DESCRIPTION
Telemeter client makes no api requests and has no role or role bindings,
so we do not need to allocate a service account.

Openshift does not let you run as user 65534, so let's omit this for
now, we can always add it again later.

The repo for Telemeter is quay.io/openshift/origin-telemeter

cc @s-urbaniak 