### PR TITLE
add service account with correct roles to telemeter-client

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter/client"
                 }
             },
-            "version": "e42df32b074384e8c0f256dceb7a7ce1c8329b1e"
+            "version": "6354ed97330a1d439749217f2a74f883494b1e94"
         },
         {
             "name": "ksonnet",

--- a/manifests/telemeter-client-clusterRole.yaml
+++ b/manifests/telemeter-client-clusterRole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: telemeter-client
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get

--- a/manifests/telemeter-client-clusterRoleBinding.yaml
+++ b/manifests/telemeter-client-clusterRoleBinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: telemeter-client
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: telemeter-client
+subjects:
+- kind: ServiceAccount
+  name: telemeter-client
+  namespace: openshift-monitoring

--- a/manifests/telemeter-client-deployment.yaml
+++ b/manifests/telemeter-client-deployment.yaml
@@ -45,6 +45,7 @@ spec:
         - mountPath: /etc/telemeter
           name: credentials
           readOnly: false
+      serviceAccountName: telemeter-client
       volumes:
       - name: credentials
         secret:

--- a/manifests/telemeter-client-serviceAccount.yaml
+++ b/manifests/telemeter-client-serviceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: telemeter-client
+  namespace: openshift-monitoring


### PR DESCRIPTION
In order to authenticate against a Prometheus k8s pod created by the Cluster Monitoring Operator, the bearer token must belong to a ServiceAccount with the following SAR `{"resource":"namespaces","verb":"get"}` [0]

[0] https://github.com/openshift/cluster-monitoring-operator/blob/master/jsonnet/prometheus.jsonnet#L290

cc @s-urbaniak 