### PR TITLE
secure telemeter client with rbac proxy

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter/client"
                 }
             },
-            "version": "6354ed97330a1d439749217f2a74f883494b1e94"
+            "version": "6957d0003574b79d24ab21f2a18ba22ae359d424"
         },
         {
             "name": "ksonnet",

--- a/manifests/telemeter-client-clusterRole.yaml
+++ b/manifests/telemeter-client-clusterRole.yaml
@@ -4,6 +4,18 @@ metadata:
   name: telemeter-client
 rules:
 - apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - ""
   resources:
   - namespaces

--- a/manifests/telemeter-client-deployment.yaml
+++ b/manifests/telemeter-client-deployment.yaml
@@ -45,8 +45,32 @@ spec:
         - mountPath: /etc/telemeter
           name: credentials
           readOnly: false
+      - args:
+        - --secure-listen-address=:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        image: quay.io/coreos/kube-rbac-proxy:v0.3.1
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          limits:
+            cpu: 20m
+            memory: 40Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: telemeter-client-tls
+          readOnly: false
       serviceAccountName: telemeter-client
       volumes:
       - name: credentials
         secret:
           secretName: telemeter-client
+      - name: telemeter-client-tls
+        secret:
+          secretName: telemeter-client-tls

--- a/manifests/telemeter-client-service.yaml
+++ b/manifests/telemeter-client-service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: telemeter-client-tls
   labels:
     k8s-app: telemeter-client
   name: telemeter-client
@@ -8,8 +10,8 @@ metadata:
 spec:
   clusterIP: None
   ports:
-  - name: http
-    port: 8080
-    targetPort: http
+  - name: https
+    port: 8443
+    targetPort: https
   selector:
     k8s-app: telemeter-client

--- a/manifests/telemeter-client-serviceMonitor.yaml
+++ b/manifests/telemeter-client-serviceMonitor.yaml
@@ -7,9 +7,13 @@ metadata:
   namespace: openshift-monitoring
 spec:
   endpoints:
-  - interval: 30s
-    port: http
-    scheme: http
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: https
+    scheme: https
+    tlsConfig:
+      caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+      serverName: server-name-replaced-at-runtime
   jobLabel: k8s-app
   selector:
     matchLabels:


### PR DESCRIPTION
Currently, nothing can scrape the Telemeter clients metrics because it is only listening on localhost. In order to expose the Telemeter client's metrics to a prometheus server, we must allow other pods to access its `/metrics` endpoint. However, the Telemeter client can potentially expose sensitive user data on its metrics endpoint. For this reason, we need to add a proxy that exposes the metrics endpoint only to authorized applications.


cc @s-urbaniak 