### PR TITLE
add match file to Telemeter client

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter/client"
                 }
             },
-            "version": "6957d0003574b79d24ab21f2a18ba22ae359d424"
+            "version": "d2e54c174935192066c51cf50e2f990c63dc143e"
         },
         {
             "name": "ksonnet",

--- a/manifests/telemeter-client-deployment.yaml
+++ b/manifests/telemeter-client-deployment.yaml
@@ -25,6 +25,7 @@ spec:
         - --to=$(TO)
         - --to-token-file=/etc/telemeter/token
         - --listen=localhost:8080
+        - --match-file=/etc/telemeter/match-rules
         env:
         - name: ID
           valueFrom:
@@ -43,7 +44,7 @@ spec:
           name: http
         volumeMounts:
         - mountPath: /etc/telemeter
-          name: credentials
+          name: secret-telemeter-client
           readOnly: false
       - args:
         - --secure-listen-address=:8443
@@ -68,7 +69,7 @@ spec:
           readOnly: false
       serviceAccountName: telemeter-client
       volumes:
-      - name: credentials
+      - name: secret-telemeter-client
         secret:
           secretName: telemeter-client
       - name: telemeter-client-tls

--- a/manifests/telemeter-client-secret.yaml
+++ b/manifests/telemeter-client-secret.yaml
@@ -1,5 +1,6 @@
 apiVersion: v1
 data:
+  match-rules: e19fbmFtZV9fPSJ1cCJ9CntfX25hbWVfXz0ib3BlbnNoaWZ0X2J1aWxkX2luZm8ifQp7X19uYW1lX189Im1hY2hpbmVfY3B1X2NvcmVzIn0Ke19fbmFtZV9fPSJtYWNoaW5lX21lbW9yeV9ieXRlcyJ9CntfX25hbWVfXz0iZXRjZF9vYmplY3RfY291bnRzIn0Ke19fbmFtZV9fPSJBTEVSVFMiLGFsZXJ0c3RhdGU9ImZpcmluZyJ9
   to: ""
 kind: Secret
 metadata:


### PR DESCRIPTION
This PR adds the `match-file` flag to the Telemeter client deployment.

cc @s-urbaniak 