### PR TITLE
Add RHD credentials to deploy configs

### DIFF
--- a/deploy/telemeter-server.yaml
+++ b/deploy/telemeter-server.yaml
@@ -96,6 +96,21 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: RHD_URL
+            valueFrom:
+              secretKeyRef:
+                name: telemeter
+                key: rhd.url
+          - name: RHD_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: telemeter
+                key: rhd.username
+          - name: RHD_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: telemeter
+                key: rhd.password
           command:
           - /usr/bin/telemeter-server
           - --join=telemeter-cluster

--- a/deploy/telemeter.secret.yaml
+++ b/deploy/telemeter.secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: telemeter
+type: Opaque
+data:
+  rhd.url: Y2hhbmdlbWU=
+  rhd.username: Y2hhbmdlbWU=
+  rhd.password: Y2hhbmdlbWU=


### PR DESCRIPTION
This adds a sample secret resource as well as link to the values as env variables in the telemeter-server deployment. 