### PR TITLE
deploy: bump telemeter-client for api.ci

### DIFF
--- a/deploy/telemeter-client-openshift.yaml
+++ b/deploy/telemeter-client-openshift.yaml
@@ -24,7 +24,7 @@ items:
             secretName: telemeter-client
         containers:
         - name: client
-          image: openshift/origin-telemeter:v3.11
+          image: openshift/origin-telemeter:v4.0
           resources:
             requests:
               cpu: 5m

--- a/deploy/telemeter-client.yaml
+++ b/deploy/telemeter-client.yaml
@@ -24,7 +24,7 @@ items:
             secretName: telemeter-client
         containers:
         - name: client
-          image: openshift/origin-telemeter:v3.11
+          image: openshift/origin-telemeter:v4.0
           resources:
             requests:
               cpu: 5m


### PR DESCRIPTION
https://github.com/openshift/release/blob/9c980ba/ci-operator/templates/cluster-launch-e2e.yaml#L132
points to the client which is supposed to be deployed during a e2e
test.

Currently, v3.11 telemeter clients are deployed, but it should be
v4.0.

This fixes it.

/cc @squat 