### PR TITLE
add jsonnet for prometheus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ manifests: $(JSONNET_SRC) $(JSONNET_VENDOR)
 	rm -rf manifests
 	mixtool build jsonnet/client.jsonnet -J jsonnet/vendor -m manifests/client
 	mixtool build jsonnet/server.jsonnet -J jsonnet/vendor -m manifests/server
+	mixtool build jsonnet/prometheus.jsonnet -J jsonnet/vendor -m manifests/prometheus
 
 $(JSONNET_VENDOR): jsonnet/jsonnetfile.json
 	cd jsonnet && jb install

--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -19,6 +19,16 @@
                 }
             },
             "version": "."
+        },
+        {
+            "name": "prometheus-telemeter",
+            "source": {
+                "git": {
+                    "remote": "../",
+                    "subdir": "jsonnet/telemeter/prometheus"
+                }
+            },
+            "version": "."
         }
     ]
 }

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter/client"
                 }
             },
-            "version": "3b283ef78cd9c70457008cbd9003037c60c192c4"
+            "version": "8a44d83d389b756b3737f58bf8987dd95a47f343"
         },
         {
             "name": "ksonnet",
@@ -28,7 +28,17 @@
                     "subdir": "jsonnet/telemeter/server"
                 }
             },
-            "version": "3b283ef78cd9c70457008cbd9003037c60c192c4"
+            "version": "8a44d83d389b756b3737f58bf8987dd95a47f343"
+        },
+        {
+            "name": "prometheus-telemeter",
+            "source": {
+                "git": {
+                    "remote": "../",
+                    "subdir": "jsonnet/telemeter/prometheus"
+                }
+            },
+            "version": "8a44d83d389b756b3737f58bf8987dd95a47f343"
         }
     ]
 }

--- a/jsonnet/prometheus.jsonnet
+++ b/jsonnet/prometheus.jsonnet
@@ -1,0 +1,3 @@
+local t = (import 'prometheus-telemeter/prometheus-telemeter.libsonnet');
+
+{ [name]: t.prometheus[name] for name in std.objectFields(t.prometheus) }

--- a/jsonnet/telemeter/prometheus/kubernetes/kubernetes.libsonnet
+++ b/jsonnet/telemeter/prometheus/kubernetes/kubernetes.libsonnet
@@ -1,0 +1,332 @@
+local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
+
+{
+  _config+:: {
+    namespace: 'telemeter',
+
+    versions+:: {
+      openshiftOauthProxy: 'v1.1.0',
+      prometheus: 'v2.3.2',
+    },
+
+    imageRepos+:: {
+      openshiftOauthProxy: 'openshift/oauth-proxy',
+      prometheus: 'quay.io/prometheus/prometheus',
+    },
+
+    prometheus+:: {
+      name: 'telemeter',
+      replicas: 2,
+      rules: { groups: [] },
+      htpasswdAuth: '',
+      sessionSecret: '',
+    },
+  },
+
+  prometheus+:: {
+    // The proxy secret is there to encrypt session created by the oauth proxy.
+    proxySecret:
+      local secret = k.core.v1.secret;
+
+      secret.new('prometheus-%s-proxy' % $._config.prometheus.name, {
+        session_secret: std.base64($._config.prometheus.sessionSecret),
+      }) +
+      secret.mixin.metadata.withNamespace($._config.namespace) +
+      secret.mixin.metadata.withLabels({ 'k8s-app': 'prometheus-' + $._config.prometheus.name }),
+
+    htpasswdSecret:
+      local secret = k.core.v1.secret;
+
+      secret.new('prometheus-%s-htpasswd' % $._config.prometheus.name, {
+        auth: std.base64($._config.prometheus.htpasswdAuth),
+      }) +
+      secret.mixin.metadata.withNamespace($._config.namespace) +
+      secret.mixin.metadata.withLabels({ 'k8s-app': 'prometheus-' + $._config.prometheus.name }),
+
+    route: {
+      apiVersion: 'v1',
+      kind: 'Route',
+      metadata: {
+        name: 'prometheus-' + $._config.prometheus.name,
+        namespace: $._config.namespace,
+      },
+      spec: {
+        to: {
+          kind: 'Service',
+          name: 'prometheus-' + $._config.prometheus.name,
+        },
+        port: {
+          targetPort: 'https',
+        },
+        tls: {
+          termination: 'Reencrypt',
+        },
+      },
+    },
+
+    serviceAccount:
+      local serviceAccount = k.core.v1.serviceAccount;
+
+      serviceAccount.new('prometheus-' + $._config.prometheus.name) +
+      serviceAccount.mixin.metadata.withNamespace($._config.namespace) +
+      serviceAccount.mixin.metadata.withAnnotations({
+        'serviceaccounts.openshift.io/oauth-redirectreference.prometheus-k8s': '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"prometheus-telemeter"}}',
+      }),
+
+    service:
+      local service = k.core.v1.service;
+      local servicePort = k.core.v1.service.mixin.spec.portsType;
+
+      local prometheusPort = servicePort.newNamed('https', 9091, 'https');
+
+      service.new('prometheus-' + $._config.prometheus.name, { app: 'prometheus', prometheus: $._config.prometheus.name }, prometheusPort) +
+      service.mixin.metadata.withNamespace($._config.namespace) +
+      service.mixin.metadata.withLabels({ prometheus: $._config.prometheus.name }) +
+      service.mixin.metadata.withAnnotations({
+        'service.alpha.openshift.io/serving-cert-secret-name': 'prometheus-telemeter-tls',
+      }) +
+      service.mixin.spec.withType('ClusterIP'),
+
+    rules:
+      {
+        apiVersion: 'monitoring.coreos.com/v1',
+        kind: 'PrometheusRule',
+        metadata: {
+          labels: {
+            prometheus: $._config.prometheus.name,
+            role: 'alert-rules',
+          },
+          name: 'prometheus-' + $._config.prometheus.name + '-rules',
+          namespace: $._config.namespace,
+        },
+        spec: {
+          groups: $._config.prometheus.rules.groups,
+        },
+      },
+
+    roleSpecificNamespaces:
+      local role = k.rbac.v1.role;
+      local policyRule = role.rulesType;
+      local coreRule =
+        policyRule.new() +
+        policyRule.withApiGroups(['']) +
+        policyRule.withResources([
+          'nodes',
+          'services',
+          'endpoints',
+          'pods',
+        ]) +
+        policyRule.withVerbs(['get', 'list', 'watch']);
+
+      role.new() +
+      role.mixin.metadata.withName('prometheus-' + $._config.prometheus.name) +
+      role.mixin.metadata.withNamespace($._config.namespace) +
+      role.withRules(coreRule),
+
+    roleBindingSpecificNamespaces:
+      local roleBinding = k.rbac.v1.roleBinding;
+
+      roleBinding.new() +
+      roleBinding.mixin.metadata.withName('prometheus-' + $._config.prometheus.name) +
+      roleBinding.mixin.metadata.withNamespace($._config.namespace) +
+      roleBinding.mixin.roleRef.withApiGroup('rbac.authorization.k8s.io') +
+      roleBinding.mixin.roleRef.withName('prometheus-' + $._config.prometheus.name) +
+      roleBinding.mixin.roleRef.mixinInstance({ kind: 'Role' }) +
+      roleBinding.withSubjects([{ kind: 'ServiceAccount', name: 'prometheus-' + $._config.prometheus.name, namespace: $._config.namespace }]),
+
+
+    roleConfig:
+      local role = k.rbac.v1.role;
+      local policyRule = role.rulesType;
+
+      local configmapRule =
+        policyRule.new() +
+        policyRule.withApiGroups(['']) +
+        policyRule.withResources([
+          'configmaps',
+        ]) +
+        policyRule.withVerbs(['get']);
+
+      role.new() +
+      role.mixin.metadata.withName('prometheus-' + $._config.prometheus.name + '-config') +
+      role.mixin.metadata.withNamespace($._config.namespace) +
+      role.withRules(configmapRule),
+
+    roleBindingConfig:
+      local roleBinding = k.rbac.v1.roleBinding;
+
+      roleBinding.new() +
+      roleBinding.mixin.metadata.withName('prometheus-' + $._config.prometheus.name + '-config') +
+      roleBinding.mixin.metadata.withNamespace($._config.namespace) +
+      roleBinding.mixin.roleRef.withApiGroup('rbac.authorization.k8s.io') +
+      roleBinding.mixin.roleRef.withName('prometheus-' + $._config.prometheus.name + '-config') +
+      roleBinding.mixin.roleRef.mixinInstance({ kind: 'Role' }) +
+      roleBinding.withSubjects([{ kind: 'ServiceAccount', name: 'prometheus-' + $._config.prometheus.name, namespace: $._config.namespace }]),
+
+    clusterRole:
+      local clusterRole = k.rbac.v1.clusterRole;
+      local policyRule = clusterRole.rulesType;
+
+      local metricsRule =
+        policyRule.new() +
+        policyRule.withNonResourceUrls('/metrics') +
+        policyRule.withVerbs(['get']);
+
+      local authenticationRule =
+        policyRule.new() +
+        policyRule.withApiGroups(['authentication.k8s.io']) +
+        policyRule.withResources([
+          'tokenreviews',
+        ]) +
+        policyRule.withVerbs(['create']);
+
+      local authorizationRule =
+        policyRule.new() +
+        policyRule.withApiGroups(['authorization.k8s.io']) +
+        policyRule.withResources([
+          'subjectaccessreviews',
+        ]) +
+        policyRule.withVerbs(['create']);
+
+      local namespacesRule =
+        policyRule.new() +
+        policyRule.withApiGroups(['']) +
+        policyRule.withResources([
+          'namespaces',
+        ]) +
+        policyRule.withVerbs(['get']);
+
+      clusterRole.new() +
+      clusterRole.mixin.metadata.withName('prometheus-' + $._config.prometheus.name) +
+      clusterRole.withRules([metricsRule, authenticationRule, authorizationRule, namespacesRule]),
+
+    clusterRoleBinding:
+      local clusterRoleBinding = k.rbac.v1.clusterRoleBinding;
+
+      clusterRoleBinding.new() +
+      clusterRoleBinding.mixin.metadata.withName('prometheus-' + $._config.prometheus.name) +
+      clusterRoleBinding.mixin.roleRef.withApiGroup('rbac.authorization.k8s.io') +
+      clusterRoleBinding.mixin.roleRef.withName('prometheus-' + $._config.prometheus.name) +
+      clusterRoleBinding.mixin.roleRef.mixinInstance({ kind: 'ClusterRole' }) +
+      clusterRoleBinding.withSubjects([{ kind: 'ServiceAccount', name: 'prometheus-' + $._config.prometheus.name, namespace: $._config.namespace }]),
+
+    prometheus:
+      local container = k.core.v1.pod.mixin.spec.containersType;
+      local resourceRequirements = container.mixin.resourcesType;
+      local selector = k.apps.v1beta2.deployment.mixin.spec.selectorType;
+
+      local resources =
+        resourceRequirements.new() +
+        resourceRequirements.withRequests({ memory: '400Mi' });
+
+      {
+        apiVersion: 'monitoring.coreos.com/v1',
+        kind: 'Prometheus',
+        metadata: {
+          name: $._config.prometheus.name,
+          namespace: $._config.namespace,
+          labels: {
+            prometheus: $._config.prometheus.name,
+          },
+        },
+        spec: {
+          replicas: $._config.prometheus.replicas,
+          version: $._config.versions.prometheus,
+          baseImage: $._config.imageRepos.prometheus,
+          securityContext: {},
+          serviceAccountName: 'prometheus-' + $._config.prometheus.name,
+          nodeSelector: { 'beta.kubernetes.io/os': 'linux' },
+          resources: resources,
+          ruleSelector: selector.withMatchLabels({
+            role: 'alert-rules',
+            prometheus: $._config.prometheus.name,
+          }),
+          secrets+: [
+            'prometheus-%s-tls' % $._config.prometheus.name,
+            'prometheus-%s-proxy' % $._config.prometheus.name,
+            'prometheus-%s-htpasswd' % $._config.prometheus.name,
+          ],
+          serviceMonitorSelector: selector.withMatchLabels({ 'k8s-app': 'telemeter-server' }),
+          serviceMonitorNamespaceSelector: selector.withMatchLabels({ 'k8s-app': 'telemeter-server' }),
+          listenLocal: true,
+          containers: [
+            {
+              name: 'prometheus-proxy',
+              image: $._config.imageRepos.openshiftOauthProxy + ':' + $._config.versions.openshiftOauthProxy,
+              resources: {},
+              ports: [
+                {
+                  containerPort: 9091,
+                  name: 'https',
+                },
+              ],
+              args: [
+                '-provider=openshift',
+                '-https-address=:9091',
+                '-http-address=',
+                '-email-domain=*',
+                '-upstream=http://localhost:9090',
+                '-htpasswd-file=/etc/proxy/htpasswd/auth',
+                '-openshift-service-account=prometheus-' + $._config.prometheus.name,
+                '-openshift-sar={"resource": "namespaces", "verb": "get"}',
+                '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}',
+                '-tls-cert=/etc/tls/private/tls.crt',
+                '-tls-key=/etc/tls/private/tls.key',
+                '-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token',
+                '-cookie-secret-file=/etc/proxy/secrets/session_secret',
+                '-openshift-ca=/etc/pki/tls/cert.pem',
+                '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
+                '-skip-auth-regex=^/metrics',
+              ],
+              volumeMounts: [
+                {
+                  mountPath: '/etc/tls/private',
+                  name: 'secret-prometheus-%s-tls' % $._config.prometheus.name,
+                },
+                {
+                  mountPath: '/etc/proxy/secrets',
+                  name: 'secret-prometheus-%s-proxy' % $._config.prometheus.name,
+                },
+                {
+                  mountPath: '/etc/proxy/htpasswd',
+                  name: 'secret-prometheus-%s-htpasswd' % $._config.prometheus.name,
+                },
+              ],
+            },
+          ],
+        },
+      },
+
+    serviceMonitor:
+      {
+        apiVersion: 'monitoring.coreos.com/v1',
+        kind: 'ServiceMonitor',
+        metadata: {
+          name: 'prometheus-' + $._config.prometheus.name,
+          namespace: $._config.namespace,
+          labels: {
+            'k8s-app': 'prometheus',
+          },
+        },
+        spec: {
+          selector: {
+            matchLabels: {
+              prometheus: $._config.prometheus.name,
+            },
+          },
+          endpoints: [
+            {
+              port: 'https',
+              interval: '30s',
+              scheme: 'https',
+              tlsConfig: {
+                caFile: '/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt',
+                serverName: 'prometheus-%s.%s.svc' % [$._config.prometheus.name, $._config.namespace],
+              },
+              bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+            },
+          ],
+        },
+      },
+  },
+}

--- a/jsonnet/telemeter/prometheus/kubernetes/list.libsonnet
+++ b/jsonnet/telemeter/prometheus/kubernetes/list.libsonnet
@@ -1,0 +1,63 @@
+{
+  asList(name, data, parameters):: {
+    apiVersion: 'v1',
+    kind: 'Template',
+    metadata: {
+      name: name,
+    },
+    objects: [data[k] for k in std.objectFields(data)],
+    parameters: parameters,
+  },
+
+  withImage(_config):: {
+    local setImage(object) =
+      if object.kind == 'Prometheus' then {
+        spec+: {
+          baseImage: '${IMAGE}',
+          version: ':${IMAGE_TAG}',
+          containers: [
+            if c.name == 'prometheus-proxy' then c {
+              image: '${PROXY_IMAGE}:${PROXY_IMAGE_TAG}',
+            } else c
+            for c in super.containers
+          ],
+        },
+      }
+      else {},
+    objects: [
+      o + setImage(o)
+      for o in super.objects
+    ],
+    parameters+: [
+      { name: 'IMAGE', value: _config.imageRepos.prometheus },
+      { name: 'IMAGE_TAG', value: _config.versions.prometheus },
+      { name: 'PROXY_IMAGE', value: _config.imageRepos.openshiftOauthProxy },
+      { name: 'PROXY_IMAGE_TAG', value: _config.versions.openshiftOauthProxy },
+    ],
+  },
+
+  withNamespace(_config):: {
+    local setNamespace(object) =
+      if std.objectHas(object, 'metadata') && std.objectHas(object.metadata, 'namespace') then {
+        metadata+: {
+          namespace: '${NAMESPACE}',
+        },
+      }
+      else {},
+    local setSubjectNamespace(object) =
+      if std.endsWith(object.kind, 'Binding') then {
+        subjects: [
+          s { namespace: '${NAMESPACE}' }
+          for s in super.subjects
+        ],
+      }
+      else {},
+    objects: [
+      o + setNamespace(o) + setSubjectNamespace(o)
+      for o in super.objects
+    ],
+    parameters+: [
+      { name: 'NAMESPACE', value: _config.namespace },
+    ],
+  },
+}

--- a/jsonnet/telemeter/prometheus/prometheus-telemeter.libsonnet
+++ b/jsonnet/telemeter/prometheus/prometheus-telemeter.libsonnet
@@ -1,0 +1,14 @@
+local list = import 'kubernetes/list.libsonnet';
+
+(import 'kubernetes/kubernetes.libsonnet') + {
+  local p = super.prometheus,
+  prometheus+:: {
+    list: list.asList('prometheus-telemeter', p, []) + list.withImage($._config) + list.withNamespace($._config),
+  },
+} + {
+  _config+:: {
+    jobs+: {
+      PrometheusTelemeter: 'job="prometheus-telemeter"',
+    },
+  },
+}

--- a/jsonnet/telemeter/server/kubernetes/list.libsonnet
+++ b/jsonnet/telemeter/server/kubernetes/list.libsonnet
@@ -11,10 +11,10 @@
 
   withImage(_config):: {
     local setImage(object) =
-      if object.kind == 'StatefulSet' then object { image: '${IMAGE}:${IMAGE_TAG}' }
-      else object,
+      if object.kind == 'StatefulSet' then { image: '${IMAGE}:${IMAGE_TAG}' }
+      else {},
     objects: [
-      setImage(o)
+      o + setImage(o)
       for o in super.objects
     ],
     parameters+: [
@@ -24,8 +24,8 @@
   },
 
   withAuthorizeURL(_config):: {
-    local setImage(object) =
-      if object.kind == 'StatefulSet' then object {
+    local setAuthorizeURL(object) =
+      if object.kind == 'StatefulSet' then {
         spec+: {
           template+: {
             spec+: {
@@ -42,9 +42,9 @@
           },
         },
       }
-      else object,
+      else {},
     objects: [
-      setImage(o)
+      o + setAuthorizeURL(o)
       for o in super.objects
     ],
     parameters+: [

--- a/manifests/prometheus/clusterRole.yaml
+++ b/manifests/prometheus/clusterRole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-telemeter
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get

--- a/manifests/prometheus/clusterRoleBinding.yaml
+++ b/manifests/prometheus/clusterRoleBinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-telemeter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-telemeter
+subjects:
+- kind: ServiceAccount
+  name: prometheus-telemeter
+  namespace: telemeter

--- a/manifests/prometheus/htpasswdSecret.yaml
+++ b/manifests/prometheus/htpasswdSecret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  auth: ""
+kind: Secret
+metadata:
+  labels:
+    k8s-app: prometheus-telemeter
+  name: prometheus-telemeter-htpasswd
+  namespace: telemeter
+type: Opaque

--- a/manifests/prometheus/list.yaml
+++ b/manifests/prometheus/list.yaml
@@ -1,0 +1,261 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: prometheus-telemeter
+objects:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: prometheus-telemeter
+  rules:
+  - nonResourceURLs:
+    - /metrics
+    verbs:
+    - get
+  - apiGroups:
+    - authentication.k8s.io
+    resources:
+    - tokenreviews
+    verbs:
+    - create
+  - apiGroups:
+    - authorization.k8s.io
+    resources:
+    - subjectaccessreviews
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    resources:
+    - namespaces
+    verbs:
+    - get
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: prometheus-telemeter
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: prometheus-telemeter
+  subjects:
+  - kind: ServiceAccount
+    name: prometheus-telemeter
+    namespace: ${NAMESPACE}
+- apiVersion: v1
+  data:
+    auth: ""
+  kind: Secret
+  metadata:
+    labels:
+      k8s-app: prometheus-telemeter
+    name: prometheus-telemeter-htpasswd
+    namespace: ${NAMESPACE}
+  type: Opaque
+- apiVersion: monitoring.coreos.com/v1
+  kind: Prometheus
+  metadata:
+    labels:
+      prometheus: telemeter
+    name: telemeter
+    namespace: ${NAMESPACE}
+  spec:
+    baseImage: ${IMAGE}
+    containers:
+    - args:
+      - -provider=openshift
+      - -https-address=:9091
+      - -http-address=
+      - -email-domain=*
+      - -upstream=http://localhost:9090
+      - -htpasswd-file=/etc/proxy/htpasswd/auth
+      - -openshift-service-account=prometheus-telemeter
+      - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
+      - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
+      - -tls-cert=/etc/tls/private/tls.crt
+      - -tls-key=/etc/tls/private/tls.key
+      - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+      - -cookie-secret-file=/etc/proxy/secrets/session_secret
+      - -openshift-ca=/etc/pki/tls/cert.pem
+      - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - -skip-auth-regex=^/metrics
+      image: ${PROXY_IMAGE}:${PROXY_IMAGE_TAG}
+      name: prometheus-proxy
+      ports:
+      - containerPort: 9091
+        name: https
+      resources: {}
+      volumeMounts:
+      - mountPath: /etc/tls/private
+        name: secret-prometheus-telemeter-tls
+      - mountPath: /etc/proxy/secrets
+        name: secret-prometheus-telemeter-proxy
+      - mountPath: /etc/proxy/htpasswd
+        name: secret-prometheus-telemeter-htpasswd
+    listenLocal: true
+    nodeSelector:
+      beta.kubernetes.io/os: linux
+    replicas: 2
+    resources:
+      requests:
+        memory: 400Mi
+    ruleSelector:
+      matchLabels:
+        prometheus: telemeter
+        role: alert-rules
+    secrets:
+    - prometheus-telemeter-tls
+    - prometheus-telemeter-proxy
+    - prometheus-telemeter-htpasswd
+    securityContext: {}
+    serviceAccountName: prometheus-telemeter
+    serviceMonitorNamespaceSelector:
+      matchLabels:
+        k8s-app: telemeter-server
+    serviceMonitorSelector:
+      matchLabels:
+        k8s-app: telemeter-server
+    version: :${IMAGE_TAG}
+- apiVersion: v1
+  data:
+    session_secret: ""
+  kind: Secret
+  metadata:
+    labels:
+      k8s-app: prometheus-telemeter
+    name: prometheus-telemeter-proxy
+    namespace: ${NAMESPACE}
+  type: Opaque
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: prometheus-telemeter-config
+    namespace: ${NAMESPACE}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: prometheus-telemeter-config
+  subjects:
+  - kind: ServiceAccount
+    name: prometheus-telemeter
+    namespace: ${NAMESPACE}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: prometheus-telemeter
+    namespace: ${NAMESPACE}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: prometheus-telemeter
+  subjects:
+  - kind: ServiceAccount
+    name: prometheus-telemeter
+    namespace: ${NAMESPACE}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: prometheus-telemeter-config
+    namespace: ${NAMESPACE}
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - get
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: prometheus-telemeter
+    namespace: ${NAMESPACE}
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    - services
+    - endpoints
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: prometheus-telemeter
+    namespace: ${NAMESPACE}
+  spec:
+    port:
+      targetPort: https
+    tls:
+      termination: Reencrypt
+    to:
+      kind: Service
+      name: prometheus-telemeter
+- apiVersion: monitoring.coreos.com/v1
+  kind: PrometheusRule
+  metadata:
+    labels:
+      prometheus: telemeter
+      role: alert-rules
+    name: prometheus-telemeter-rules
+    namespace: ${NAMESPACE}
+  spec:
+    groups: []
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: prometheus-telemeter-tls
+    labels:
+      prometheus: telemeter
+    name: prometheus-telemeter
+    namespace: ${NAMESPACE}
+  spec:
+    ports:
+    - name: https
+      port: 9091
+      targetPort: https
+    selector:
+      app: prometheus
+      prometheus: telemeter
+    type: ClusterIP
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    annotations:
+      serviceaccounts.openshift.io/oauth-redirectreference.prometheus-k8s: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"prometheus-telemeter"}}'
+    name: prometheus-telemeter
+    namespace: ${NAMESPACE}
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    labels:
+      k8s-app: prometheus
+    name: prometheus-telemeter
+    namespace: ${NAMESPACE}
+  spec:
+    endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      port: https
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        serverName: prometheus-telemeter.telemeter.svc
+    selector:
+      matchLabels:
+        prometheus: telemeter
+parameters:
+- name: IMAGE
+  value: quay.io/prometheus/prometheus
+- name: IMAGE_TAG
+  value: v2.3.2
+- name: PROXY_IMAGE
+  value: openshift/oauth-proxy
+- name: PROXY_IMAGE_TAG
+  value: v1.1.0
+- name: NAMESPACE
+  value: telemeter

--- a/manifests/prometheus/prometheus.yaml
+++ b/manifests/prometheus/prometheus.yaml
@@ -1,0 +1,64 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  labels:
+    prometheus: telemeter
+  name: telemeter
+  namespace: telemeter
+spec:
+  baseImage: quay.io/prometheus/prometheus
+  containers:
+  - args:
+    - -provider=openshift
+    - -https-address=:9091
+    - -http-address=
+    - -email-domain=*
+    - -upstream=http://localhost:9090
+    - -htpasswd-file=/etc/proxy/htpasswd/auth
+    - -openshift-service-account=prometheus-telemeter
+    - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
+    - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
+    - -tls-cert=/etc/tls/private/tls.crt
+    - -tls-key=/etc/tls/private/tls.key
+    - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+    - -cookie-secret-file=/etc/proxy/secrets/session_secret
+    - -openshift-ca=/etc/pki/tls/cert.pem
+    - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    - -skip-auth-regex=^/metrics
+    image: openshift/oauth-proxy:v1.1.0
+    name: prometheus-proxy
+    ports:
+    - containerPort: 9091
+      name: https
+    resources: {}
+    volumeMounts:
+    - mountPath: /etc/tls/private
+      name: secret-prometheus-telemeter-tls
+    - mountPath: /etc/proxy/secrets
+      name: secret-prometheus-telemeter-proxy
+    - mountPath: /etc/proxy/htpasswd
+      name: secret-prometheus-telemeter-htpasswd
+  listenLocal: true
+  nodeSelector:
+    beta.kubernetes.io/os: linux
+  replicas: 2
+  resources:
+    requests:
+      memory: 400Mi
+  ruleSelector:
+    matchLabels:
+      prometheus: telemeter
+      role: alert-rules
+  secrets:
+  - prometheus-telemeter-tls
+  - prometheus-telemeter-proxy
+  - prometheus-telemeter-htpasswd
+  securityContext: {}
+  serviceAccountName: prometheus-telemeter
+  serviceMonitorNamespaceSelector:
+    matchLabels:
+      k8s-app: telemeter-server
+  serviceMonitorSelector:
+    matchLabels:
+      k8s-app: telemeter-server
+  version: v2.3.2

--- a/manifests/prometheus/proxySecret.yaml
+++ b/manifests/prometheus/proxySecret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  session_secret: ""
+kind: Secret
+metadata:
+  labels:
+    k8s-app: prometheus-telemeter
+  name: prometheus-telemeter-proxy
+  namespace: telemeter
+type: Opaque

--- a/manifests/prometheus/roleBindingConfig.yaml
+++ b/manifests/prometheus/roleBindingConfig.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-telemeter-config
+  namespace: telemeter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-telemeter-config
+subjects:
+- kind: ServiceAccount
+  name: prometheus-telemeter
+  namespace: telemeter

--- a/manifests/prometheus/roleBindingSpecificNamespaces.yaml
+++ b/manifests/prometheus/roleBindingSpecificNamespaces.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-telemeter
+  namespace: telemeter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-telemeter
+subjects:
+- kind: ServiceAccount
+  name: prometheus-telemeter
+  namespace: telemeter

--- a/manifests/prometheus/roleConfig.yaml
+++ b/manifests/prometheus/roleConfig.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-telemeter-config
+  namespace: telemeter
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get

--- a/manifests/prometheus/roleSpecificNamespaces.yaml
+++ b/manifests/prometheus/roleSpecificNamespaces.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-telemeter
+  namespace: telemeter
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/prometheus/route.yaml
+++ b/manifests/prometheus/route.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Route
+metadata:
+  name: prometheus-telemeter
+  namespace: telemeter
+spec:
+  port:
+    targetPort: https
+  tls:
+    termination: Reencrypt
+  to:
+    kind: Service
+    name: prometheus-telemeter

--- a/manifests/prometheus/rules.yaml
+++ b/manifests/prometheus/rules.yaml
@@ -1,0 +1,10 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: telemeter
+    role: alert-rules
+  name: prometheus-telemeter-rules
+  namespace: telemeter
+spec:
+  groups: []

--- a/manifests/prometheus/service.yaml
+++ b/manifests/prometheus/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: prometheus-telemeter-tls
+  labels:
+    prometheus: telemeter
+  name: prometheus-telemeter
+  namespace: telemeter
+spec:
+  ports:
+  - name: https
+    port: 9091
+    targetPort: https
+  selector:
+    app: prometheus
+    prometheus: telemeter
+  type: ClusterIP

--- a/manifests/prometheus/serviceAccount.yaml
+++ b/manifests/prometheus/serviceAccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.prometheus-k8s: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"prometheus-telemeter"}}'
+  name: prometheus-telemeter
+  namespace: telemeter

--- a/manifests/prometheus/serviceMonitor.yaml
+++ b/manifests/prometheus/serviceMonitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: prometheus
+  name: prometheus-telemeter
+  namespace: telemeter
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: https
+    scheme: https
+    tlsConfig:
+      caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+      serverName: prometheus-telemeter.telemeter.svc
+  selector:
+    matchLabels:
+      prometheus: telemeter


### PR DESCRIPTION
This PR adds the jsonnet files necessary to generate the prometheus statefulset that scrapes the telemeter server (AKA the "insights" prometheus). The PR also commits the generated yaml files.

I have tested deploying the generated files against a 3.10 openshift cluster and everything works as expected :tada:!!

In order to finish the work of scraping the telemeter server, we need to create a ServiceMonitor manifest for it.

cc @s-urbaniak @jmelis @pbergene