### PR TITLE
pkg/http/server: drop metric timestamps on federate

### DIFF
--- a/cmd/telemeter-server/main_test.go
+++ b/cmd/telemeter-server/main_test.go
@@ -114,6 +114,12 @@ func TestGet(t *testing.T) {
 	actual := mustGet(s.URL, expfmt.FmtText)
 	expected := mustReadString(sampleMetrics)
 
+	for _, mf := range expected {
+		for _, m := range mf.Metric {
+			m.TimestampMs = nil
+		}
+	}
+
 	if e, a := metricsAsStringOrDie(expected), metricsAsStringOrDie(actual); e != a {
 		t.Errorf("unexpected output metrics:\n%s\n%s", e, a)
 	}

--- a/pkg/http/server/server.go
+++ b/pkg/http/server/server.go
@@ -65,6 +65,8 @@ func (s *Server) Get(w http.ResponseWriter, req *http.Request) {
 		filter.With(metricfamily.TransformerFunc(metricfamily.PackMetrics))
 	}
 
+	filter.With(metricfamily.TransformerFunc(metricfamily.DropTimestamp))
+
 	err := s.store.ReadMetrics(ctx, minTimeMs, func(partitionKey string, families []*clientmodel.MetricFamily) error {
 		for _, family := range families {
 			if family == nil {

--- a/pkg/http/server/server_test.go
+++ b/pkg/http/server/server_test.go
@@ -20,7 +20,11 @@ func family(name string, timestamps ...int64) *clientmodel.MetricFamily {
 	families := &clientmodel.MetricFamily{Name: &name}
 	for i := range timestamps {
 		one := float64(1)
-		families.Metric = append(families.Metric, &clientmodel.Metric{Counter: &clientmodel.Counter{Value: &one}, TimestampMs: &timestamps[i]})
+		ts := &timestamps[i]
+		if *ts < 0 {
+			ts = nil
+		}
+		families.Metric = append(families.Metric, &clientmodel.Metric{Counter: &clientmodel.Counter{Value: &one}, TimestampMs: ts})
 	}
 	return families
 }
@@ -67,8 +71,8 @@ func TestServer_Get(t *testing.T) {
 				Method: "GET",
 			},
 			wantFamilies: []*clientmodel.MetricFamily{
-				family("test_1", 1002000, 1004000),
-				family("test_2", 1002000, 1004000),
+				family("test_1", -1, -1),
+				family("test_2", -1, -1),
 			},
 			wantCode: 200,
 		},
@@ -92,7 +96,7 @@ func TestServer_Get(t *testing.T) {
 			sort.Slice(families, func(i, j int) bool { return families[i].GetName() < families[j].GetName() })
 			got, expected := familiesToText(families), familiesToText(tt.wantFamilies)
 			if got != expected {
-				t.Fatalf("unexpected result\n%s\n%s", got, expected)
+				t.Fatalf("got\n%s\nwant\n%s", got, expected)
 			}
 		})
 	}

--- a/pkg/metricfamily/drop_timestamp.go
+++ b/pkg/metricfamily/drop_timestamp.go
@@ -1,0 +1,19 @@
+package metricfamily
+
+import clientmodel "github.com/prometheus/client_model/go"
+
+// DropTimestamp is a transformer that removes timestamps from metrics.
+func DropTimestamp(family *clientmodel.MetricFamily) (bool, error) {
+	if family == nil {
+		return true, nil
+	}
+
+	for _, m := range family.Metric {
+		if m == nil {
+			continue
+		}
+		m.TimestampMs = nil
+	}
+
+	return true, nil
+}

--- a/pkg/metricfamily/drop_timestamp_test.go
+++ b/pkg/metricfamily/drop_timestamp_test.go
@@ -1,0 +1,115 @@
+package metricfamily
+
+import (
+	"fmt"
+	"testing"
+
+	clientmodel "github.com/prometheus/client_model/go"
+)
+
+func TestDropTimestamp(t *testing.T) {
+
+	family := func(name string, metrics ...*clientmodel.Metric) *clientmodel.MetricFamily {
+		families := &clientmodel.MetricFamily{Name: &name}
+		for _, m := range metrics {
+			families.Metric = append(families.Metric, m)
+		}
+		return families
+	}
+
+	metric := func(timestamp *int64) *clientmodel.Metric { return &clientmodel.Metric{TimestampMs: timestamp} }
+
+	timestamp := func(timestamp int64) *int64 { return &timestamp }
+
+	type checkFunc func(family *clientmodel.MetricFamily, ok bool, err error) error
+
+	isOK := func(want bool) checkFunc {
+		return func(_ *clientmodel.MetricFamily, got bool, _ error) error {
+			if want != got {
+				return fmt.Errorf("want ok %t, got %t", want, got)
+			}
+			return nil
+		}
+	}
+
+	hasErr := func(want error) checkFunc {
+		return func(_ *clientmodel.MetricFamily, _ bool, got error) error {
+			if want != got {
+				return fmt.Errorf("want err %v, got %v", want, got)
+			}
+			return nil
+		}
+	}
+
+	hasMetrics := func(want int) checkFunc {
+		return func(m *clientmodel.MetricFamily, _ bool, _ error) error {
+			if got := len(m.Metric); want != got {
+				return fmt.Errorf("want len(m.Metric)=%v, got %v", want, got)
+			}
+			return nil
+		}
+	}
+
+	metricsHaveTimestamps := func(want bool) checkFunc {
+		return func(m *clientmodel.MetricFamily, _ bool, _ error) error {
+			for _, metric := range m.Metric {
+				if got := metric.TimestampMs != nil; want != got {
+					return fmt.Errorf("want metrics to have timestamp %t, got %t", want, got)
+				}
+			}
+			return nil
+		}
+	}
+
+	for _, tc := range []struct {
+		family *clientmodel.MetricFamily
+		name   string
+		checks []checkFunc
+	}{
+		{
+			name: "nil family",
+			checks: []checkFunc{
+				isOK(true),
+				hasErr(nil),
+			},
+		},
+		{
+			name:   "family without timestamp",
+			family: family("foo"),
+			checks: []checkFunc{
+				isOK(true),
+				hasErr(nil),
+			},
+		},
+		{
+			name:   "family without timestamp",
+			family: family("foo", metric(nil)),
+			checks: []checkFunc{
+				isOK(true),
+				hasErr(nil),
+				hasMetrics(1),
+				metricsHaveTimestamps(false),
+			},
+		},
+		{
+			name:   "family with timestamp",
+			family: family("foo", metric(nil), metric(timestamp(1))),
+			checks: []checkFunc{
+				isOK(true),
+				hasErr(nil),
+				hasMetrics(2),
+				metricsHaveTimestamps(false),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, err := DropTimestamp(tc.family)
+
+			for _, check := range tc.checks {
+				if err := check(tc.family, ok, err); err != nil {
+					t.Error(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently, timestamps are preserved from the most recent client push.
In case of telemeter client push failures this causes metrics scraped from telemeter server
to report the same timestamp of the most recently pushed metrics until either:

a) the client subsequently pushes new metrics successfully,
effectively updating the timestamp of the most recently pushed metrics.

or

b) after a 10 minute window the most recently pushed metric is being removed.

Prometheus, when scraping metrics including timestamps, does not consider them to be stale
if the timestamp between does not change, but they are removed from the graph after 5 minutes
(not configurable) effectively disabling the above 10 minute window.

This fixes it by not forwarding metric timestamps.
Prometheus in that case will consider those metrics to become stale
only after they are not available any more at the federate endpoint,
which happens after the 10 minute time window.

Fixes MON-302

/cc @squat 