### PR TITLE
jsonnet,metrics: move metrics to independent json

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter/client"
                 }
             },
-            "version": "10bc45ef84340888d3aed658ef1419d029324fee"
+            "version": "8f85beb0e6b41c9b7c694090014d980ed596a950"
         },
         {
             "name": "ksonnet",
@@ -28,7 +28,7 @@
                     "subdir": "jsonnet/telemeter/server"
                 }
             },
-            "version": "10bc45ef84340888d3aed658ef1419d029324fee"
+            "version": "8f85beb0e6b41c9b7c694090014d980ed596a950"
         },
         {
             "name": "prometheus-telemeter",
@@ -38,7 +38,7 @@
                     "subdir": "jsonnet/telemeter/prometheus"
                 }
             },
-            "version": "10bc45ef84340888d3aed658ef1419d029324fee"
+            "version": "8f85beb0e6b41c9b7c694090014d980ed596a950"
         }
     ]
 }

--- a/jsonnet/telemeter/client/kubernetes/kubernetes.libsonnet
+++ b/jsonnet/telemeter/client/kubernetes/kubernetes.libsonnet
@@ -19,14 +19,7 @@ local securePort = 8443;
       from: 'https://prometheus-k8s.%(namespace)s.svc:9091' % $._config,
       serverName: 'server-name-replaced-at-runtime',
       to: 'https://infogw.api.openshift.com',
-      matchRules: [
-        '{__name__="up"}',
-        '{__name__="openshift_build_info"}',
-        '{__name__="machine_cpu_cores"}',
-        '{__name__="machine_memory_bytes"}',
-        '{__name__="etcd_object_counts"}',
-        '{__name__="ALERTS",alertstate="firing"}',
-      ],
+      matchRules: [],
     },
 
     versions+:: {

--- a/jsonnet/telemeter/client/metrics.json
+++ b/jsonnet/telemeter/client/metrics.json
@@ -1,0 +1,8 @@
+[
+    "{__name__=\"up\"}",
+    "{__name__=\"openshift_build_info\"}",
+    "{__name__=\"machine_cpu_cores\"}",
+    "{__name__=\"machine_memory_bytes\"}",
+    "{__name__=\"etcd_object_counts\"}",
+    "{__name__=\"ALERTS\",alertstate=\"firing\"}"
+]

--- a/jsonnet/telemeter/client/telemeter-client.libsonnet
+++ b/jsonnet/telemeter/client/telemeter-client.libsonnet
@@ -3,5 +3,8 @@
     jobs+: {
       TelemeterClient: 'job="telemeter-client"',
     },
+    telemeterClient+: {
+      matchRules+: (import 'metrics.json'),
+    },
   },
 }

--- a/metrics.json
+++ b/metrics.json
@@ -1,0 +1,1 @@
+jsonnet/telemeter/client/metrics.json


### PR DESCRIPTION
Move the labels to match metrics to an independent JSON file. This makes
it easier for contributors to inspect and modify the labels used to
select metrics without needing to understand jsonnet. The repository
root contains a symlink to the labels file for ease of discovery.

cc @s-urbaniak @brancz 