### PR TITLE
 jsonnet: reference cluster-monitoring-view

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter/client"
                 }
             },
-            "version": "8f85beb0e6b41c9b7c694090014d980ed596a950"
+            "version": "ff6a5cfa95650bf2ddb4382e364d4f5f3dbeb1d7"
         },
         {
             "name": "ksonnet",
@@ -28,7 +28,7 @@
                     "subdir": "jsonnet/telemeter/server"
                 }
             },
-            "version": "8f85beb0e6b41c9b7c694090014d980ed596a950"
+            "version": "ff6a5cfa95650bf2ddb4382e364d4f5f3dbeb1d7"
         },
         {
             "name": "prometheus-telemeter",
@@ -38,7 +38,7 @@
                     "subdir": "jsonnet/telemeter/prometheus"
                 }
             },
-            "version": "8f85beb0e6b41c9b7c694090014d980ed596a950"
+            "version": "ff6a5cfa95650bf2ddb4382e364d4f5f3dbeb1d7"
         }
     ]
 }

--- a/jsonnet/telemeter/client/kubernetes/kubernetes.libsonnet
+++ b/jsonnet/telemeter/client/kubernetes/kubernetes.libsonnet
@@ -62,17 +62,19 @@ local securePort = 8443;
                                 ]) +
                                 policyRule.withVerbs(['create']);
 
-      local coreRule = policyRule.new() +
-                       policyRule.withApiGroups(['']) +
-                       policyRule.withResources([
-                         'namespaces',
-                       ]) +
-                       policyRule.withVerbs(['get']);
-
-
       clusterRole.new() +
       clusterRole.mixin.metadata.withName('telemeter-client') +
-      clusterRole.withRules([authenticationRule, authorizationRule, coreRule]),
+      clusterRole.withRules([authenticationRule, authorizationRule]),
+
+    clusterRoleBindingView:
+      local clusterRoleBinding = k.rbac.v1.clusterRoleBinding;
+
+      clusterRoleBinding.new() +
+      clusterRoleBinding.mixin.metadata.withName('telemeter-client-view') +
+      clusterRoleBinding.mixin.roleRef.withApiGroup('rbac.authorization.k8s.io') +
+      clusterRoleBinding.mixin.roleRef.withName('cluster-monitoring-view') +
+      clusterRoleBinding.mixin.roleRef.mixinInstance({ kind: 'ClusterRole' }) +
+      clusterRoleBinding.withSubjects([{ kind: 'ServiceAccount', name: 'telemeter-client', namespace: $._config.namespace }]),
 
     deployment:
       local deployment = k.apps.v1beta2.deployment;

--- a/manifests/client/clusterRole.yaml
+++ b/manifests/client/clusterRole.yaml
@@ -15,9 +15,3 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get

--- a/manifests/client/clusterRoleBindingView.yaml
+++ b/manifests/client/clusterRoleBindingView.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: telemeter-client-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+- kind: ServiceAccount
+  name: telemeter-client
+  namespace: openshift-monitoring


### PR DESCRIPTION
This commit changes the Telemeter client configuration to bind against
an existing `cluster-monitoring-view` ClusterRole, rather than creating
a ClusterRole that duplicates this one. The reasoning for this is that
if the definition of the permissions required for the
`cluster-monitoring-view` change, then the Telemeter code base does not
need to change.

cc @brancz @s-urbaniak 

addresses: https://github.com/openshift/telemeter/pull/35#issuecomment-429854862