### PR TITLE
jsonnet/telemeter/client: add support for salt

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter/client"
                 }
             },
-            "version": "f15a6b81d93ccbe4069ce57367ef8f4a9ba785a9"
+            "version": "e715bf437ef93e5c285e98fa6fbae49b8555f445"
         },
         {
             "name": "ksonnet",
@@ -28,7 +28,7 @@
                     "subdir": "jsonnet/telemeter/server"
                 }
             },
-            "version": "f15a6b81d93ccbe4069ce57367ef8f4a9ba785a9"
+            "version": "e715bf437ef93e5c285e98fa6fbae49b8555f445"
         },
         {
             "name": "prometheus-telemeter",
@@ -38,7 +38,7 @@
                     "subdir": "jsonnet/telemeter/prometheus"
                 }
             },
-            "version": "f15a6b81d93ccbe4069ce57367ef8f4a9ba785a9"
+            "version": "e715bf437ef93e5c285e98fa6fbae49b8555f445"
         }
     ]
 }

--- a/manifests/client/deployment.yaml
+++ b/manifests/client/deployment.yaml
@@ -26,6 +26,7 @@ spec:
         - --to-token-file=/etc/telemeter/token
         - --listen=localhost:8080
         - --match-file=/etc/telemeter/match-rules
+        - --anonymize-salt-file=/etc/telemeter/salt
         env:
         - name: ID
           valueFrom:

--- a/manifests/client/secret.yaml
+++ b/manifests/client/secret.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 data:
   match-rules: e19fbmFtZV9fPSJ1cCJ9CntfX25hbWVfXz0ib3BlbnNoaWZ0X2J1aWxkX2luZm8ifQp7X19uYW1lX189Im1hY2hpbmVfY3B1X2NvcmVzIn0Ke19fbmFtZV9fPSJtYWNoaW5lX21lbW9yeV9ieXRlcyJ9CntfX25hbWVfXz0iZXRjZF9vYmplY3RfY291bnRzIn0Ke19fbmFtZV9fPSJBTEVSVFMiLGFsZXJ0c3RhdGU9ImZpcmluZyJ9
+  salt: ""
   to: aHR0cHM6Ly9pbmZvZ3cuYXBpLm9wZW5zaGlmdC5jb20=
+  token: ""
 kind: Secret
 metadata:
   labels:


### PR DESCRIPTION
This commit adds support for using a salt to anonymize metrics reported
by the client.

cc @s-urbaniak 