### PR TITLE
jsonnet/telemeter/server: re-add name env var

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter/client"
                 }
             },
-            "version": "7ae19324562a0f66e3edc51df55bc13bd4912a36"
+            "version": "08b593ca9919b8e0defeb6577ceaa2f587d51484"
         },
         {
             "name": "ksonnet",
@@ -28,7 +28,7 @@
                     "subdir": "jsonnet/telemeter/server"
                 }
             },
-            "version": "7ae19324562a0f66e3edc51df55bc13bd4912a36"
+            "version": "08b593ca9919b8e0defeb6577ceaa2f587d51484"
         },
         {
             "name": "prometheus-telemeter",
@@ -38,7 +38,7 @@
                     "subdir": "jsonnet/telemeter/prometheus"
                 }
             },
-            "version": "7ae19324562a0f66e3edc51df55bc13bd4912a36"
+            "version": "08b593ca9919b8e0defeb6577ceaa2f587d51484"
         }
     ]
 }

--- a/jsonnet/telemeter/server/kubernetes/kubernetes.libsonnet
+++ b/jsonnet/telemeter/server/kubernetes/kubernetes.libsonnet
@@ -46,7 +46,6 @@ local clusterPort = 8081;
       local tlsMount = containerVolumeMount.new(tlsVolumeName, tlsMountPath);
       local tlsVolume = volume.fromSecret(tlsVolumeName, tlsSecret);
       local name = containerEnv.fromFieldPath('NAME', 'metadata.name');
-      local namespace = containerEnv.fromFieldPath('NAMESPACE', 'metadata.namespace');
       local rhdURL = containerEnv.fromSecretRef('RHD_URL', secretName, 'rhd.url');
       local rhdUsername = containerEnv.fromSecretRef('RHD_USERNAME', secretName, 'rhd.username');
       local rhdPassword = containerEnv.fromSecretRef('RHD_PASSWORD', secretName, 'rhd.password');
@@ -77,7 +76,7 @@ local clusterPort = 8081;
           containerPort.newNamed('cluster', clusterPort),
         ]) +
         container.withVolumeMounts([tlsMount, localMount]) +
-        container.withEnv([rhdURL, rhdUsername, rhdPassword, rhdClientID]) + {
+        container.withEnv([name, rhdURL, rhdUsername, rhdPassword, rhdClientID]) + {
           livenessProbe: {
             httpGet: {
               path: '/healthz',

--- a/manifests/server/list.yaml
+++ b/manifests/server/list.yaml
@@ -99,6 +99,10 @@ objects:
           - --authorize-username=$(RHD_USERNAME)
           - --authorize-password=$(RHD_PASSWORD)
           env:
+          - name: NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           - name: RHD_URL
             valueFrom:
               secretKeyRef:

--- a/manifests/server/statefulSet.yaml
+++ b/manifests/server/statefulSet.yaml
@@ -33,6 +33,10 @@ spec:
         - --authorize-username=$(RHD_USERNAME)
         - --authorize-password=$(RHD_PASSWORD)
         env:
+        - name: NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: RHD_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This PR re-introduces the `NAME` environment variable, which was accidentally omitted.

cc @jfchevrette @s-urbaniak 
fixes: https://github.com/openshift/telemeter/issues/68