### PR TITLE
rules: Gather cluster version metrics from a cluster

### DIFF
--- a/deploy/default-rules
+++ b/deploy/default-rules
@@ -1,5 +1,9 @@
 {__name__="up"}
-{__name__="openshift_build_info"}
+{__name__="cluster_version"}
+{__name__="cluster_operator_up"}
+{__name__="cluster_operator_conditions"}
+{__name__="cluster_version_payload"}
+{__name__="cluster_version_payload_errors"}
 {__name__="machine_cpu_cores"}
 {__name__="machine_memory_bytes"}
 {__name__="etcd_object_counts"}

--- a/jsonnet/telemeter/client/metrics.json
+++ b/jsonnet/telemeter/client/metrics.json
@@ -1,6 +1,10 @@
 [
     "{__name__=\"up\"}",
-    "{__name__=\"openshift_build_info\"}",
+    "{__name__=\"cluster_version\"}",
+    "{__name__=\"cluster_operator_up\"}",
+    "{__name__=\"cluster_operator_conditions\"}",
+    "{__name__=\"cluster_version_payload\"}",
+    "{__name__=\"cluster_version_payload_errors\"}",
     "{__name__=\"machine_cpu_cores\"}",
     "{__name__=\"machine_memory_bytes\"}",
     "{__name__=\"etcd_object_counts\"}",


### PR DESCRIPTION
openshift/cluster-version-operator#45 and openshift/cluster-version-operator#47
added a set of core metrics to the cluster version operator to report on the
version of the cluster, the health of the cluster operators, and any payload
errors. As these metrics are of key importance to safe rollout of automated
upgrades to a cluster, gather and report them to telemetry.

These metrics have limited privacy impact when gathering since we only track
version strings. A future release may return the payload image used to carry
the update, which might include local registry information.

See https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/metrics.md for a description of the metrics being captured.

@derekwaynecarr