### PR TITLE
Add Configmap Reload to client

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter/client"
                 }
             },
-            "version": "73ca309b6be2ab94d4adaa0683e05ede4d94ae78"
+            "version": "c717061d7753ad3a60f6b91fa72fa25b3639763b"
         },
         {
             "name": "ksonnet",
@@ -28,7 +28,7 @@
                     "subdir": "jsonnet/telemeter/server"
                 }
             },
-            "version": "73ca309b6be2ab94d4adaa0683e05ede4d94ae78"
+            "version": "c717061d7753ad3a60f6b91fa72fa25b3639763b"
         },
         {
             "name": "prometheus-telemeter",
@@ -38,7 +38,7 @@
                     "subdir": "jsonnet/telemeter/prometheus"
                 }
             },
-            "version": "73ca309b6be2ab94d4adaa0683e05ede4d94ae78"
+            "version": "c717061d7753ad3a60f6b91fa72fa25b3639763b"
         }
     ]
 }

--- a/jsonnet/telemeter/client/kubernetes/kubernetes.libsonnet
+++ b/jsonnet/telemeter/client/kubernetes/kubernetes.libsonnet
@@ -28,6 +28,7 @@ local securePort = 8443;
     },
 
     versions+:: {
+      // TODO(squat): change this to v4.0 once that image is built
       configmapReload: 'v3.11',
       kubeRbacProxy: 'v0.3.1',
       telemeterClient: 'v4.0',

--- a/manifests/client/deployment.yaml
+++ b/manifests/client/deployment.yaml
@@ -57,6 +57,15 @@ spec:
           name: secret-telemeter-client
           readOnly: false
       - args:
+        - --webhook-url=http://localhost:9000/-/reload
+        - --volume-dir=/etc/serving-certs-ca-bundle
+        image: quay.io/openshift/origin-configmap-reload:v3.11
+        name: reload
+        volumeMounts:
+        - mountPath: /etc/serving-certs-ca-bundle
+          name: serving-certs-ca-bundle
+          readOnly: false
+      - args:
         - --secure-listen-address=:8443
         - --upstream=http://127.0.0.1:8080/
         - --tls-cert-file=/etc/tls/private/tls.crt


### PR DESCRIPTION
This PR finalizes support for the new Service Certs CA Bundle interface
by adding a configmap reload container to the Telemeter client Pod.
This container will watch the CA bundle volume and POST to the Telemeter
client's new `/-/reload` endpoint to trigger a reconfiguration of the container.

Note: this PR uses the v3.11 tag of the configmap-reload container as there
is currently no v4.0 image. Once that image is built, we should bump this.

cc @s-urbaniak @brancz 