### PR TITLE
Scrape Federate Endpoint

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter/client"
                 }
             },
-            "version": "c717061d7753ad3a60f6b91fa72fa25b3639763b"
+            "version": "3e683a6dd14e9959cef9e938b5c107dc67d39d56"
         },
         {
             "name": "ksonnet",
@@ -28,7 +28,7 @@
                     "subdir": "jsonnet/telemeter/server"
                 }
             },
-            "version": "c717061d7753ad3a60f6b91fa72fa25b3639763b"
+            "version": "3e683a6dd14e9959cef9e938b5c107dc67d39d56"
         },
         {
             "name": "prometheus-telemeter",
@@ -38,7 +38,7 @@
                     "subdir": "jsonnet/telemeter/prometheus"
                 }
             },
-            "version": "c717061d7753ad3a60f6b91fa72fa25b3639763b"
+            "version": "3e683a6dd14e9959cef9e938b5c107dc67d39d56"
         }
     ]
 }

--- a/jsonnet/telemeter/prometheus/kubernetes/kubernetes.libsonnet
+++ b/jsonnet/telemeter/prometheus/kubernetes/kubernetes.libsonnet
@@ -138,7 +138,6 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       roleBinding.mixin.roleRef.mixinInstance({ kind: 'Role' }) +
       roleBinding.withSubjects([{ kind: 'ServiceAccount', name: 'prometheus-' + $._config.prometheus.name, namespace: $._config.namespace }]),
 
-
     roleConfig:
       local role = k.rbac.v1.role;
       local policyRule = role.rulesType;
@@ -250,8 +249,10 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
             'prometheus-%s-proxy' % $._config.prometheus.name,
             'prometheus-%s-htpasswd' % $._config.prometheus.name,
           ],
-          serviceMonitorSelector: selector.withMatchLabels({ 'k8s-app': 'telemeter-server' }),
-          serviceMonitorNamespaceSelector: selector.withMatchLabels({ 'k8s-app': 'telemeter-server' }),
+          serviceMonitorSelector: selector.withMatchLabels({
+            'k8s-app': 'telemeter-server',
+            endpoint: 'federate',
+          }),
           listenLocal: true,
           containers: [
             {

--- a/manifests/prometheus/list.yaml
+++ b/manifests/prometheus/list.yaml
@@ -111,11 +111,9 @@ objects:
     - prometheus-telemeter-htpasswd
     securityContext: {}
     serviceAccountName: prometheus-telemeter
-    serviceMonitorNamespaceSelector:
-      matchLabels:
-        k8s-app: telemeter-server
     serviceMonitorSelector:
       matchLabels:
+        endpoint: federate
         k8s-app: telemeter-server
     version: ${IMAGE_TAG}
 - apiVersion: v1

--- a/manifests/prometheus/prometheus.yaml
+++ b/manifests/prometheus/prometheus.yaml
@@ -55,10 +55,8 @@ spec:
   - prometheus-telemeter-htpasswd
   securityContext: {}
   serviceAccountName: prometheus-telemeter
-  serviceMonitorNamespaceSelector:
-    matchLabels:
-      k8s-app: telemeter-server
   serviceMonitorSelector:
     matchLabels:
+      endpoint: federate
       k8s-app: telemeter-server
   version: v2.3.2

--- a/manifests/server/list.yaml
+++ b/manifests/server/list.yaml
@@ -48,6 +48,7 @@ objects:
   kind: ServiceMonitor
   metadata:
     labels:
+      endpoint: metrics
       k8s-app: telemeter-server
     name: telemeter-server
     namespace: telemeter
@@ -55,6 +56,32 @@ objects:
     endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       interval: 30s
+      port: external
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        serverName: server-name-replaced-at-runtime
+    jobLabel: k8s-app
+    selector:
+      matchLabels:
+        k8s-app: telemeter-server
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    labels:
+      endpoint: federate
+      k8s-app: telemeter-server
+    name: telemeter-server-feredate
+    namespace: telemeter
+  spec:
+    endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      honorLabels: true
+      interval: 15s
+      params:
+        match[]:
+        - '{__name__=~".*"}'
+      path: /federate
       port: external
       scheme: https
       tlsConfig:

--- a/manifests/server/serviceMonitorFederate.yaml
+++ b/manifests/server/serviceMonitorFederate.yaml
@@ -2,14 +2,19 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    endpoint: metrics
+    endpoint: federate
     k8s-app: telemeter-server
-  name: telemeter-server
+  name: telemeter-server-feredate
   namespace: telemeter
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    interval: 30s
+    honorLabels: true
+    interval: 15s
+    params:
+      match[]:
+      - '{__name__=~".*"}'
+    path: /federate
     port: external
     scheme: https
     tlsConfig:


### PR DESCRIPTION
This commit adds a new ServiceMonitor object that is configured to
scrape the Telemeter server `/federate` endpoint. It also reconfigures
the Prometheus object to only match ServiceMonitors that specify a
federation label.

cc @s-urbaniak 