### PR TITLE
jsonnet/telemeter/client: fix configMap volume

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter/client"
                 }
             },
-            "version": "3e683a6dd14e9959cef9e938b5c107dc67d39d56"
+            "version": "415dd4080dd6ab1075ffa0ea5e40262e9b2bd443"
         },
         {
             "name": "ksonnet",
@@ -28,7 +28,7 @@
                     "subdir": "jsonnet/telemeter/server"
                 }
             },
-            "version": "3e683a6dd14e9959cef9e938b5c107dc67d39d56"
+            "version": "415dd4080dd6ab1075ffa0ea5e40262e9b2bd443"
         },
         {
             "name": "prometheus-telemeter",
@@ -38,7 +38,7 @@
                     "subdir": "jsonnet/telemeter/prometheus"
                 }
             },
-            "version": "3e683a6dd14e9959cef9e938b5c107dc67d39d56"
+            "version": "415dd4080dd6ab1075ffa0ea5e40262e9b2bd443"
         }
     ]
 }

--- a/jsonnet/telemeter/client/kubernetes/kubernetes.libsonnet
+++ b/jsonnet/telemeter/client/kubernetes/kubernetes.libsonnet
@@ -98,7 +98,7 @@ local securePort = 8443;
       local tlsMount = containerVolumeMount.new(tlsVolumeName, tlsMountPath);
       local tlsVolume = volume.fromSecret(tlsVolumeName, tlsSecret);
       local sccabMount = containerVolumeMount.new(servingCertsCABundle, servingCertsCABundleMountPath);
-      local sccabVolume = volume.fromConfigMap(servingCertsCABundle, servingCertsCABundle, servingCertsCABundleFileName);
+      local sccabVolume = volume.withName(servingCertsCABundle) + volume.mixin.configMap.withName('telemeter-client-serving-certs-ca-bundle');
       local anonymize = containerEnv.fromSecretRef('ANONYMIZE_LABELS', secretName, 'anonymizeLabels');
       local id = containerEnv.fromSecretRef('ID', secretName, 'id');
       local to = containerEnv.fromSecretRef('TO', secretName, 'to');
@@ -219,7 +219,7 @@ local securePort = 8443;
     servingCertsCABundle+:
       local configmap = k.core.v1.configMap;
 
-      configmap.new('telemeter-serving-certs-ca-bundle', { [servingCertsCABundleFileName]: '' }) +
+      configmap.new('telemeter-client-serving-certs-ca-bundle', { [servingCertsCABundleFileName]: '' }) +
       configmap.mixin.metadata.withNamespace($._config.namespace) +
       configmap.mixin.metadata.withAnnotations({ 'service.alpha.openshift.io/inject-cabundle': 'true' }),
   },

--- a/manifests/client/deployment.yaml
+++ b/manifests/client/deployment.yaml
@@ -89,9 +89,7 @@ spec:
       serviceAccountName: telemeter-client
       volumes:
       - configMap:
-          items:
-          - service-ca.crt
-          name: serving-certs-ca-bundle
+          name: telemeter-client-serving-certs-ca-bundle
         name: serving-certs-ca-bundle
       - name: secret-telemeter-client
         secret:

--- a/manifests/client/servingCertsCABundle.yaml
+++ b/manifests/client/servingCertsCABundle.yaml
@@ -5,5 +5,5 @@ kind: ConfigMap
 metadata:
   annotations:
     service.alpha.openshift.io/inject-cabundle: "true"
-  name: telemeter-serving-certs-ca-bundle
+  name: telemeter-client-serving-certs-ca-bundle
   namespace: openshift-monitoring


### PR DESCRIPTION
Burned again by the ksonnet constructors :p

This commit fixes the definition of the Volume for the serving certs CA
bundle ConfigMap. Instead of specifying a list of key-path pairs to
load explicitly, we let the Volume load all keys from the ConfigMap.
Unfortunately the Volume constructor for ConfigMaps requires a list of
items, so we bypass the constructor and use the mixins to generate the
volume.

cc @s-urbaniak 