### PR TITLE
pkg/authorize/jwt: fix handling of required labels

### DIFF
--- a/pkg/authorize/jwt/handler.go
+++ b/pkg/authorize/jwt/handler.go
@@ -95,6 +95,9 @@ func (a *authorizeClusterHandler) ServeHTTP(w http.ResponseWriter, req *http.Req
 	labels := map[string]string{
 		a.partitionKey: cluster,
 	}
+	for k, v := range a.labels {
+		labels[k] = v
+	}
 
 	// create a token that asserts the client and the labels
 	authToken, err := a.signer.GenerateToken(Claims(subject, labels, a.expireInSeconds, []string{"federate"}))

--- a/pkg/http/server/server_test.go
+++ b/pkg/http/server/server_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openshift/telemeter/pkg/store"
 	"github.com/openshift/telemeter/pkg/store/memstore"
+	"github.com/openshift/telemeter/pkg/validate"
 	clientmodel "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 )
@@ -46,7 +47,7 @@ func storeWithData(data map[string][]*clientmodel.MetricFamily) store.Store {
 func TestServer_Get(t *testing.T) {
 	type fields struct {
 		store     store.Store
-		validator UploadValidator
+		validator validate.Validator
 		nowFn     func() time.Time
 	}
 	tests := []struct {

--- a/pkg/metricfamily/multi_transformer.go
+++ b/pkg/metricfamily/multi_transformer.go
@@ -10,7 +10,9 @@ type MultiTransformer struct {
 }
 
 func (a *MultiTransformer) With(t Transformer) {
-	a.transformers = append(a.transformers, t)
+	if t != nil {
+		a.transformers = append(a.transformers, t)
+	}
 }
 
 func (a *MultiTransformer) WithFunc(f func() Transformer) {


### PR DESCRIPTION
This commit fixes the handling of required labels in the JWT package.
Formerly, the JWT authorizer constructor accepted a labels parameter,
but this map was never actually used by the type. This commit fixes the
handling of the parameter so that the labels are added to the JWT. This
means that the labels will now be respected as required labels in the
validator.

This commit also cleans up some general label handling. For example, the
validator was had the responsibility of adding additional labels
to the received metrics, when this really has nothing to do with
validation; it is instead a general purpose transformation. This has
been extracted and put instead into the `Post` handler so that the label
addition occurs after successful validation.

cc @s-urbaniak 