### PR TITLE
pkg/forwarder: allow no labels to be anonymized

### DIFF
--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -115,8 +115,11 @@ func New(cfg Config) (*Worker, error) {
 		}
 		anonymizeSalt = strings.TrimSpace(string(data))
 	}
-	if (len(cfg.AnonymizeLabels) != 0) != (len(anonymizeSalt) != 0) {
-		return nil, fmt.Errorf("both anonymize-salt and anonymize-labels must be either specified or empty")
+	if len(cfg.AnonymizeLabels) != 0 && len(anonymizeSalt) == 0 {
+		return nil, fmt.Errorf("anonymize-salt must be specified if anonymize-labels is set")
+	}
+	if len(cfg.AnonymizeLabels) == 0 {
+		log.Printf("warning: not anonymizing any labels")
 	}
 
 	// Configure a transformer.

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -91,10 +91,18 @@ func TestNew(t *testing.T) {
 			err: true,
 		},
 		{
-			// Providing only `AnonymizeSalt` should error.
+			// Providing only `AnonymizeSalt` should not error.
 			c: Config{
 				From:          from,
 				AnonymizeSalt: "1",
+			},
+			err: false,
+		},
+		{
+			// Providing only `AnonymizeLabels` should error.
+			c: Config{
+				From:            from,
+				AnonymizeLabels: []string{"foo"},
 			},
 			err: true,
 		},
@@ -102,7 +110,7 @@ func TestNew(t *testing.T) {
 			// Providing only `AnonymizeSalt` and `AnonymizeLabels should not error.
 			c: Config{
 				From:            from,
-				AnonymizeLabels: []string{""},
+				AnonymizeLabels: []string{"foo"},
 				AnonymizeSalt:   "1",
 			},
 			err: false,
@@ -111,7 +119,7 @@ func TestNew(t *testing.T) {
 			// Providing an invalid `AnonymizeSaltFile` should error.
 			c: Config{
 				From:              from,
-				AnonymizeLabels:   []string{""},
+				AnonymizeLabels:   []string{"foo"},
 				AnonymizeSaltFile: "/this/path/does/not/exist",
 			},
 			err: true,
@@ -120,7 +128,7 @@ func TestNew(t *testing.T) {
 			// Providing `AnonymizeSalt` takes preference over an invalid `AnonymizeSaltFile` and should not error.
 			c: Config{
 				From:              from,
-				AnonymizeLabels:   []string{""},
+				AnonymizeLabels:   []string{"foo"},
 				AnonymizeSalt:     "1",
 				AnonymizeSaltFile: "/this/path/does/not/exist",
 			},


### PR DESCRIPTION
This commit adjusts the logic of the forwarder to allow no anonymization
labels to be specified. If this is done, a warning will be logged. It is
still disallowed to specify labels with no salt.

cc @s-urbaniak 