### PR TITLE
Revert IMAGET_TAG env var for telemeter server, add dummy IMAGE_TAG to prom template

### DIFF
--- a/manifests/prometheus/list.yaml
+++ b/manifests/prometheus/list.yaml
@@ -262,3 +262,4 @@ parameters:
   value: openshift/oauth-proxy
 - name: PROXY_IMAGE_TAG
   value: v1.1.0
+- name: IMAGE_TAG

--- a/manifests/server/list.yaml
+++ b/manifests/server/list.yaml
@@ -151,7 +151,7 @@ objects:
               secretKeyRef:
                 key: rhd.client_id
                 name: telemeter-server
-          image: ${TELEMETER_IMAGE}:${TELEMETER_IMAGE_TAG}
+          image: ${TELEMETER_IMAGE}:${IMAGE_TAG}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -186,5 +186,6 @@ parameters:
   value: telemeter
 - name: TELEMETER_IMAGE
   value: quay.io/openshift/origin-telemeter
-- name: TELEMETER_IMAGE_TAG
+- name: IMAGE_TAG
+
   value: v4.0


### PR DESCRIPTION
Revert IMAGET_TAG env var for telemeter server, add dummy IMAGE_TAG to prom template