### PR TITLE
 jsonnet/telemeter: accomodate saasherder

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter"
                 }
             },
-            "version": "c593a3f6beef7cafdcabd0bd274ecef49c8c3ac1"
+            "version": "a86a5054c3caf4e569f18ea3aca68980c77f0038"
         },
         {
             "name": "ksonnet",

--- a/jsonnet/telemeter/lib/list.libsonnet
+++ b/jsonnet/telemeter/lib/list.libsonnet
@@ -73,7 +73,7 @@
             spec+: {
               containers: [
                 c {
-                  image: if c.name == 'telemeter-server' then '${TELEMETER_IMAGE}:${TELEMETER_IMAGE_TAG}' else c.image,
+                  image: if c.name == 'telemeter-server' then '${IMAGE}:${IMAGE_TAG}' else c.image,
                 }
                 for c in super.containers
               ],
@@ -87,8 +87,8 @@
       for o in super.objects
     ],
     parameters+: [
-      { name: 'TELEMETER_IMAGE', value: _config.imageRepos.telemeterServer },
-      { name: 'TELEMETER_IMAGE_TAG', value: _config.versions.telemeterServer },
+      { name: 'IMAGE', value: _config.imageRepos.telemeterServer },
+      { name: 'IMAGE_TAG', value: _config.versions.telemeterServer },
     ],
   },
 

--- a/jsonnet/telemeter/prometheus.libsonnet
+++ b/jsonnet/telemeter/prometheus.libsonnet
@@ -3,7 +3,15 @@ local list = import 'lib/list.libsonnet';
 (import 'prometheus/kubernetes.libsonnet') + {
   local p = super.prometheus,
   prometheus+:: {
-    list: list.asList('prometheus-telemeter', p, [])
+    list: list.asList('prometheus-telemeter', p, [
+            // Saasherder requires an `IMAGE_TAG` variable
+            // to be defined in the template, but we don't
+            // want to use the generated build tag for Prometheus.
+            // Use this placeholder until Saasherder fixes
+            // their semantics.
+            // TODO(squat): eliminate this once Saasherder improves.
+            { name: 'IMAGE_TAG', value: '' },
+          ])
           + list.withNamespace($._config)
           + list.withPrometheusImage($._config),
   },

--- a/manifests/prometheus/list.yaml
+++ b/manifests/prometheus/list.yaml
@@ -252,6 +252,8 @@ objects:
       matchLabels:
         prometheus: telemeter
 parameters:
+- name: IMAGE_TAG
+  value: ""
 - name: NAMESPACE
   value: telemeter
 - name: PROMETHEUS_IMAGE

--- a/manifests/server/list.yaml
+++ b/manifests/server/list.yaml
@@ -151,7 +151,7 @@ objects:
               secretKeyRef:
                 key: rhd.client_id
                 name: telemeter-server
-          image: ${TELEMETER_IMAGE}:${TELEMETER_IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -184,7 +184,7 @@ parameters:
   value: https://api.openshift.com/api/accounts_mgmt/v1/cluster_registrations
 - name: NAMESPACE
   value: telemeter
-- name: TELEMETER_IMAGE
+- name: IMAGE
   value: quay.io/openshift/origin-telemeter
-- name: TELEMETER_IMAGE_TAG
+- name: IMAGE_TAG
   value: v4.0


### PR DESCRIPTION
Saasherder requires the `IMAGE_TAG` variable to be defined in the
template, so use this to write in the generated build tag for Telemeter
server. Also, introduce a placeholer variable for the Prometheus
template. Once Saasherder fixes these semantics, we can remove this.

cc @riuvshin @s-urbaniak 