### PR TITLE
cmd,pkg: small improvements

### DIFF
--- a/cmd/telemeter-client/main.go
+++ b/cmd/telemeter-client/main.go
@@ -220,6 +220,7 @@ func (o *Options) Run() error {
 		AnonymizeLabels:   o.AnonymizeLabels,
 		AnonymizeSalt:     o.AnonymizeSalt,
 		AnonymizeSaltFile: o.AnonymizeSaltFile,
+		Debug:             o.Verbose,
 		Interval:          o.Interval,
 		LimitBytes:        o.LimitBytes,
 		Rules:             o.Rules,

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -128,9 +128,7 @@ func New(cfg Config) (*Worker, error) {
 		transformer.With(cfg.Transformer)
 	}
 	if len(cfg.AnonymizeLabels) > 0 {
-		transformer.WithFunc(func() metricfamily.Transformer {
-			return metricfamily.NewMetricsAnonymizer(anonymizeSalt, cfg.AnonymizeLabels, nil)
-		})
+		transformer.With(metricfamily.NewMetricsAnonymizer(anonymizeSalt, cfg.AnonymizeLabels, nil))
 	}
 
 	// Create the `fromClient`.
@@ -188,9 +186,7 @@ func New(cfg Config) (*Worker, error) {
 		// set of expected labels we must include.
 		rt := authorize.NewServerRotatingRoundTripper(cfg.ToToken, cfg.ToAuthorize, toClient.Transport)
 		toClient.Transport = rt
-		transformer.WithFunc(func() metricfamily.Transformer {
-			return metricfamily.NewLabel(nil, rt)
-		})
+		transformer.With(metricfamily.NewLabel(nil, rt))
 	}
 	w.toClient = metricsclient.New(toClient, cfg.LimitBytes, w.interval, "federate_to")
 	w.transformer = transformer


### PR DESCRIPTION
These commits make some small improvements:
1. actually enable verbose logging on the client
2. simplify composition of transforms in the client forwarder

cc @s-urbaniak 