### PR TITLE
cmd/telemeter-client: add ttl, ratelimit cmdline parameters

### DIFF
--- a/cmd/telemeter-client/main.go
+++ b/cmd/telemeter-client/main.go
@@ -53,7 +53,7 @@ func main() {
 	cmd.Flags().DurationVar(&opt.Interval, "interval", opt.Interval, "The interval between scrapes. Prometheus returns the last 5 minutes of metrics when invoking the federation endpoint.")
 
 	// TODO: more complex input definition, such as a JSON struct
-	cmd.Flags().StringSliceVar(&opt.Rules, "match", opt.Rules, "Match rules to federate.")
+	cmd.Flags().StringArrayVar(&opt.Rules, "match", opt.Rules, "Match rules to federate.")
 	cmd.Flags().StringVar(&opt.RulesFile, "match-file", opt.RulesFile, "A file containing match rules to federate, one rule per line.")
 
 	cmd.Flags().StringSliceVar(&opt.LabelFlag, "label", opt.LabelFlag, "Labels to add to each outgoing metric, in key=value form.")

--- a/pkg/http/server/server.go
+++ b/pkg/http/server/server.go
@@ -60,9 +60,7 @@ func (s *Server) Get(w http.ResponseWriter, req *http.Request) {
 	var minTimeMs int64
 	var filter metricfamily.MultiTransformer
 	if s.nowFn != nil {
-		minTime := s.nowFn().Add(-s.maxSampleAge)
-		minTimeMs = minTime.UnixNano() / int64(time.Millisecond)
-		filter.With(metricfamily.NewDropExpiredSamples(minTime))
+		filter.With(metricfamily.NewDropExpiredSamples(s.nowFn().Add(-s.maxSampleAge)))
 		filter.With(metricfamily.TransformerFunc(metricfamily.PackMetrics))
 	}
 

--- a/pkg/metricfamily/expired.go
+++ b/pkg/metricfamily/expired.go
@@ -21,7 +21,7 @@ func (t *dropExpiredSamples) Transform(family *clientmodel.MetricFamily) (bool, 
 		if m == nil {
 			continue
 		}
-		if m.TimestampMs == nil || *m.TimestampMs < t.min {
+		if ts := m.GetTimestampMs(); ts < t.min {
 			family.Metric[i] = nil
 			continue
 		}

--- a/pkg/store/memstore/memstore_test.go
+++ b/pkg/store/memstore/memstore_test.go
@@ -207,7 +207,6 @@ func TestReadWriteMetrics(t *testing.T) {
 			check: checks(
 				hasErr(nil),
 				lenPartitionedMetricsIs(0),
-				deepEquals(nil),
 			),
 		},
 		{
@@ -225,7 +224,6 @@ func TestReadWriteMetrics(t *testing.T) {
 			check: checks(
 				hasErr(nil),
 				lenPartitionedMetricsIs(0),
-				deepEquals(nil),
 			),
 		},
 		{
@@ -235,7 +233,6 @@ func TestReadWriteMetrics(t *testing.T) {
 			check: checks(
 				hasErr(nil),
 				lenPartitionedMetricsIs(0),
-				deepEquals(nil),
 			),
 		},
 	} {

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -49,8 +49,8 @@ trap 'kill $(jobs -p); exit 0' EXIT
     --match '{__name__="scrape_samples_scraped"}'
 ) &
 
-( ./telemeter-server --authorize http://localhost:9001 --name instance-0 --shared-key=test/test.key --listen localhost:9003 --listen-internal localhost:9004 --listen-cluster 127.0.0.1:9006 --join 127.0.0.1:9016 -v ) &
-( ./telemeter-server --authorize http://localhost:9001 --name instance-1 --shared-key=test/test.key --listen localhost:9013 --listen-internal localhost:9014 --listen-cluster 127.0.0.1:9016 --join 127.0.0.1:9006 -v ) &
+( ./telemeter-server --ttl=24h --ratelimit=15s --authorize http://localhost:9001 --name instance-0 --shared-key=test/test.key --listen localhost:9003 --listen-internal localhost:9004 --listen-cluster 127.0.0.1:9006 --join 127.0.0.1:9016 -v ) &
+( ./telemeter-server --ttl=24h --ratelimit=15s --authorize http://localhost:9001 --name instance-1 --shared-key=test/test.key --listen localhost:9013 --listen-internal localhost:9014 --listen-cluster 127.0.0.1:9016 --join 127.0.0.1:9006 -v ) &
 
 ( prometheus --config.file=./test/prom-local.conf --web.listen-address=localhost:9005 "--storage.tsdb.path=$(mktemp -d)" --log.level=warn ) &
 


### PR DESCRIPTION
cmd/telemeter-client: add ttl, ratelimit cmdline parameters

This adds TTL and ratelimit settings as command line parameters.

pkg/store/memstore: implement copy-on-read

Currently, all metrics families read from the memory store are returned by
reference. Callers can (and are) modify them in an unsynchronized manner,
thus manipulating the memory store's internal state.

This fixes it by cloning the returned metrics families.

pkg/http/server: pass max sample age without conversion

max sample age is currently passed as a millisecond value, while
NewDropExpiredSamples expectes them to be in time.Time format.

This fixes it.

cc @squat