### PR TITLE
cmd/telemeter-server: correct default value for required labels

### DIFF
--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -122,7 +122,7 @@ func main() {
 
 	cmd.Flags().BoolVarP(&opt.Verbose, "verbose", "v", opt.Verbose, "Show verbose output.")
 
-	cmd.Flags().StringSliceVar(&opt.RequiredLabelFlag, "required-label", opt.LabelFlag, "Labels that must be present on each incoming metric, in key=value form.")
+	cmd.Flags().StringSliceVar(&opt.RequiredLabelFlag, "required-label", opt.RequiredLabelFlag, "Labels that must be present on each incoming metric, in key=value form.")
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/pkg/authorize/jwt/handler_test.go
+++ b/pkg/authorize/jwt/handler_test.go
@@ -68,6 +68,7 @@ func TestAuthorizeClusterHandler(t *testing.T) {
 	partitionKey := "partitionKey"
 	labels := map[string]string{
 		"foo": "bar",
+		"baz": "qux",
 	}
 	pk, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {


### PR DESCRIPTION
not an emergency, just a mistake :p

cc @s-urbaniak 