### PR TITLE
Fix ca bundle used to talk to telemeter client for metrics

### DIFF
--- a/jsonnet/telemeter/client/kubernetes.libsonnet
+++ b/jsonnet/telemeter/client/kubernetes.libsonnet
@@ -208,7 +208,7 @@ local securePort = 8443;
               port: 'https',
               scheme: 'https',
               tlsConfig: {
-                caFile: '/etc/prometheus/configmaps/telemeter-client-serving-certs-ca-bundle/%s' % servingCertsCABundleFileName,
+                caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/%s' % servingCertsCABundleFileName,
                 serverName: $._config.telemeterClient.serverName,
               },
             },


### PR DESCRIPTION
I was checking out latest cluster-monitoring-operator on OpenShift, and saw that telemeter was not successfully being scraped with a certificate error:

![screenshot from 2018-12-03 17-33-08](https://user-images.githubusercontent.com/4546722/49387180-83adff80-f721-11e8-8134-065a12f881f7.png)

I dug and found that kube-rbac-proxy was showing errors on requests (just an excerpt, but all log lines ever logged look like this):

```
2018/12/03 16:31:42 http: TLS handshake error from 10.129.0.12:48340: remote error: tls: bad certificate
2018/12/03 16:31:46 http: TLS handshake error from 10.128.0.39:43970: remote error: tls: bad certificate
2018/12/03 16:32:12 http: TLS handshake error from 10.129.0.12:48514: remote error: tls: bad certificate
```

So I looked at the config and found this subtle difference between the other `ServiceMonitor`s using the `service-ca.crt`.

@s-urbaniak @squat @metalmatze 