### PR TITLE
 jsonnet: fix prometheus SAR

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter"
                 }
             },
-            "version": "38d365110ec567bc8b7f4e8ce94122205a1a01c9"
+            "version": "19d60563832709f81cdb4bfcc63ac6a63944cba0"
         },
         {
             "name": "ksonnet",

--- a/manifests/prometheus/list.yaml
+++ b/manifests/prometheus/list.yaml
@@ -26,6 +26,8 @@ objects:
     - create
   - apiGroups:
     - ""
+    resourceNames:
+    - ${NAMESPACE}
     resources:
     - namespaces
     verbs:
@@ -70,10 +72,9 @@ objects:
       - -upstream=http://localhost:9090
       - -htpasswd-file=/etc/proxy/htpasswd/auth
       - -openshift-service-account=prometheus-telemeter
-      - '-openshift-sar={"resource": "namespaces", "verb": "get", "resourceName":
-        "${NAMESPACE}", "namespace": "${NAMESPACE}"}'
+      - '-openshift-sar={"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}"}'
       - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get",
-        "resourceName": "${NAMESPACE}", "namespace": "${NAMESPACE}"}}'
+        "name": "${NAMESPACE}"}}'
       - -tls-cert=/etc/tls/private/tls.crt
       - -tls-key=/etc/tls/private/tls.key
       - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
This commit fixes the definition of the SAR for the proxy sitting in
front of the Telemeter Prometheus. The SAR was specifying an undefined
field `resourceName`, which was turning the SAR into `get namespace *`
rather than `get namespace $(NAMESPACE)`, which would fail.

This commit also removes the `namespace` field from the SAR, since
namespaces themselves are not namespaced objects.

This is currently breaking programmatic access via ServiceAccount tokens
to the Telemeter Prometheus instance in production.

cc @s-urbaniak @pbergene