### PR TITLE
jsonnet: namespace non-namespaced objects

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter"
                 }
             },
-            "version": "19d60563832709f81cdb4bfcc63ac6a63944cba0"
+            "version": "8990c20b36a253dfbf943d7d5214ffce023b1400"
         },
         {
             "name": "ksonnet",

--- a/jsonnet/telemeter/lib/list.libsonnet
+++ b/jsonnet/telemeter/lib/list.libsonnet
@@ -151,8 +151,21 @@
         },
       }
       else {},
+    local namespaceNonNamespacedObjects(object) =
+      (if std.objectHas(object, 'metadata') && !std.objectHas(object.metadata, 'namespace') && std.objectHas(object.metadata, 'name') then {
+         metadata+: {
+           name: '%s-${NAMESPACE}' % super.name,
+         },
+       }
+       else {}) +
+      (if object.kind == 'ClusterRoleBinding' then {
+         roleRef+: {
+           name: '%s-${NAMESPACE}' % super.name,
+         },
+       }
+       else {}),
     objects: [
-      o + setNamespace(o) + setSubjectNamespace(o) + setPermissions(o) + setServiceMonitorServerNameNamespace(o) + setClusterRoleRuleNamespace(o)
+      o + setNamespace(o) + setSubjectNamespace(o) + setPermissions(o) + setServiceMonitorServerNameNamespace(o) + setClusterRoleRuleNamespace(o) + namespaceNonNamespacedObjects(o)
       for o in super.objects
     ],
     parameters+: [

--- a/manifests/prometheus/list.yaml
+++ b/manifests/prometheus/list.yaml
@@ -6,7 +6,7 @@ objects:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
-    name: prometheus-telemeter
+    name: prometheus-telemeter-${NAMESPACE}
   rules:
   - nonResourceURLs:
     - /metrics
@@ -35,11 +35,11 @@ objects:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
-    name: prometheus-telemeter
+    name: prometheus-telemeter-${NAMESPACE}
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: prometheus-telemeter
+    name: prometheus-telemeter-${NAMESPACE}
   subjects:
   - kind: ServiceAccount
     name: prometheus-telemeter


### PR DESCRIPTION
This commit ensures that the non-namespaced objects in the generated
template manifests will not conflict when they are created in the
same cluster. Currently, if we create a ClusterRoleBinding templated for
production and later another for staging, the ClusterRoleBinding for
staging will stomp on the binding against the production ServiceAccount.
This ensures that the names of such objects will include the
namespace name.

cc @pbergene @s-urbaniak 