### PR TITLE
telemeter: add tls cipher suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,13 +41,13 @@ test-integration: build
 vendor:
 	glide update -v --skip-test
 
-manifests: $(JSONNET_SRC) $(JSONNET_VENDOR)
+manifests: $(JSONNET_SRC) $(JSONNET_VENDOR) $(MIXTOOL_BIN)
 	rm -rf manifests
 	mixtool build jsonnet/client.jsonnet -J jsonnet/vendor -m manifests/client
 	mixtool build jsonnet/server.jsonnet -J jsonnet/vendor -m manifests/server
 	mixtool build jsonnet/prometheus.jsonnet -J jsonnet/vendor -m manifests/prometheus
 
-$(JSONNET_VENDOR): jsonnet/jsonnetfile.json
+$(JSONNET_VENDOR): jsonnet/jsonnetfile.json $(JB_BIN)
 	cd jsonnet && jb install
 
 dependencies: $(JB_BIN) $(JSONNET_BIN) $(MIXTOOL_BIN) $(GOLANGCI_LINT_BIN)

--- a/jsonnet/telemeter/client/kubernetes.libsonnet
+++ b/jsonnet/telemeter/client/kubernetes.libsonnet
@@ -137,11 +137,14 @@ local securePort = 8443;
           '--upstream=http://127.0.0.1:%s/' % metricsPort,
           '--tls-cert-file=%s/tls.crt' % tlsMountPath,
           '--tls-private-key-file=%s/tls.key' % tlsMountPath,
-        ]) +
+        ] + if std.objectHas($._config, 'tlsCipherSuites') then [
+          '--tls-cipher-suites=' + std.join(',', $._config.tlsCipherSuites),
+        ] else []) +
         container.withPorts(containerPort.new(securePort) + containerPort.withName('https')) +
         container.mixin.resources.withRequests({ cpu: '10m', memory: '20Mi' }) +
         container.mixin.resources.withLimits({ cpu: '20m', memory: '40Mi' }) +
         container.withVolumeMounts([tlsMount]);
+
 
       deployment.new('telemeter-client', 1, [telemeterClient, reload, proxy], podLabels) +
       deployment.mixin.metadata.withNamespace($._config.namespace) +


### PR DESCRIPTION
This PR ensures that the Telemeter client RBAC proxy can specify a TLS cipher suite.
Note, the cipher suite is optionally added in to allow rendering the client without specifying
a cipher suite and not have the argument `--tls-cipher-suite=""`.

cc @brancz @s-urbaniak 