### PR TITLE
 jsonnet/telemeter: bump rate-limit and replicas

### DIFF
--- a/manifests/server/list.yaml
+++ b/manifests/server/list.yaml
@@ -99,7 +99,7 @@ objects:
     namespace: ${NAMESPACE}
   spec:
     podManagementPolicy: Parallel
-    replicas: 3
+    replicas: 10
     selector:
       matchLabels:
         k8s-app: telemeter-server
@@ -128,6 +128,7 @@ objects:
           - --authorize-username=$(RHD_USERNAME)
           - --authorize-password=$(RHD_PASSWORD)
           - --whitelist-file=/etc/telemeter/whitelist
+          - --ratelimit=20s
           env:
           - name: NAME
             valueFrom:

--- a/manifests/server/statefulSet.yaml
+++ b/manifests/server/statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: telemeter
 spec:
   podManagementPolicy: Parallel
-  replicas: 3
+  replicas: 10
   selector:
     matchLabels:
       k8s-app: telemeter-server
@@ -34,6 +34,7 @@ spec:
         - --authorize-username=$(RHD_USERNAME)
         - --authorize-password=$(RHD_PASSWORD)
         - --whitelist-file=/etc/telemeter/whitelist
+        - --ratelimit=20s
         env:
         - name: NAME
           valueFrom:


### PR DESCRIPTION
Telemeter Prometheus is showing holes in the graphs due to timeouts
while Prometheus is scraping Telemeter server, where it is taking
\>10s on occasion. This commit scales the replicas so we can distribute
the metrics across the hash ring and rendering the metrics takes less
time. It also bumps the rate-limit so platforms that report metrics
on behalf of clusters, e.g. CI won't get rate-limited.

@jfchevrette @smarterclayton @brancz 