### PR TITLE
 jsonnet: bump server ratelimit

### DIFF
--- a/jsonnet/telemeter/server/kubernetes.libsonnet
+++ b/jsonnet/telemeter/server/kubernetes.libsonnet
@@ -17,10 +17,13 @@ local whitelistFileName = 'whitelist';
     telemeterServer+:: {
       authorizeURL: 'https://api.openshift.com/api/accounts_mgmt/v1/cluster_registrations',
       // By default, the rate-limit is 1 request/4.5 minutes/cluster.
-      // Telemeter server should be able to handle 1/20s/cluster without being DOSed.
-      // This will also allow clusters reporting on behalf of others, e.g. CI,
-      // To make requests more often.
-      ratelimit: '20s',
+      // This sets the rate-limit to 100 times the intended frequency.
+      // If a cluster is making requests more than every two seconds,
+      // the requests will fail. This will also allow clusters reporting
+      // on behalf of others, e.g. CI, to make requests more often.
+      // The long-term solution is to introduce per-ID limits, or
+      // a whitelist of IDs that are not rate-limited.
+      ratelimit: '2s',
       replicas: 10,
       rhdURL: '',
       rhdUsername: '',

--- a/manifests/server/list.yaml
+++ b/manifests/server/list.yaml
@@ -128,7 +128,7 @@ objects:
           - --authorize-username=$(RHD_USERNAME)
           - --authorize-password=$(RHD_PASSWORD)
           - --whitelist-file=/etc/telemeter/whitelist
-          - --ratelimit=20s
+          - --ratelimit=2s
           env:
           - name: NAME
             valueFrom:

--- a/manifests/server/statefulSet.yaml
+++ b/manifests/server/statefulSet.yaml
@@ -34,7 +34,7 @@ spec:
         - --authorize-username=$(RHD_USERNAME)
         - --authorize-password=$(RHD_PASSWORD)
         - --whitelist-file=/etc/telemeter/whitelist
-        - --ratelimit=20s
+        - --ratelimit=2s
         env:
         - name: NAME
           valueFrom:


### PR DESCRIPTION
Telemeter server is still rate-limiting CI.
This sets the rate-limit to 100 times the intended frequency.
If a cluster is making requests more than every two seconds,
the requests will fail. This will also allow clusters reporting
on behalf of others, e.g. CI, to make requests more often.
The long-term solution is to introduce per-ID limits, or
a whitelist of IDs that are not rate-limited.

cc @brancz @smarterclayton 