### PR TITLE
jsonnet: remove role for nodes

### DIFF
--- a/jsonnet/telemeter/prometheus/kubernetes.libsonnet
+++ b/jsonnet/telemeter/prometheus/kubernetes.libsonnet
@@ -115,7 +115,6 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
         policyRule.new() +
         policyRule.withApiGroups(['']) +
         policyRule.withResources([
-          'nodes',
           'services',
           'endpoints',
           'pods',

--- a/manifests/prometheus/list.yaml
+++ b/manifests/prometheus/list.yaml
@@ -174,7 +174,6 @@ objects:
   - apiGroups:
     - ""
     resources:
-    - nodes
     - services
     - endpoints
     - pods

--- a/manifests/prometheus/roleSpecificNamespaces.yaml
+++ b/manifests/prometheus/roleSpecificNamespaces.yaml
@@ -7,7 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
   - services
   - endpoints
   - pods


### PR DESCRIPTION
This commit removes the role to get/list/watch nodes
for Prometheus. This was carried over from kube-prometheus
but is no longer required, even there.

cc @brancz @jfchevrette @pbergene