### PR TITLE
 jsonnet: fix SAR

### DIFF
--- a/jsonnet/telemeter/lib/list.libsonnet
+++ b/jsonnet/telemeter/lib/list.libsonnet
@@ -100,9 +100,9 @@
             c {
               args: [
                 if std.startsWith(arg, '-openshift-sar') then
-                  '-openshift-sar={"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}"}'
+                  '-openshift-sar={"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}", "namespace": "${NAMESPACE}"}'
                 else if std.startsWith(arg, '-openshift-delegate-urls') then
-                  '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}"}}'
+                  '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}", "namespace": "${NAMESPACE}"}}'
                 else arg
                 for arg in super.args
               ],

--- a/manifests/prometheus/list.yaml
+++ b/manifests/prometheus/list.yaml
@@ -72,9 +72,10 @@ objects:
       - -upstream=http://localhost:9090
       - -htpasswd-file=/etc/proxy/htpasswd/auth
       - -openshift-service-account=prometheus-telemeter
-      - '-openshift-sar={"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}"}'
+      - '-openshift-sar={"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}",
+        "namespace": "${NAMESPACE}"}'
       - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get",
-        "name": "${NAMESPACE}"}}'
+        "name": "${NAMESPACE}", "namespace": "${NAMESPACE}"}}'
       - -tls-cert=/etc/tls/private/tls.crt
       - -tls-key=/etc/tls/private/tls.key
       - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
This commit fixes the SAR that the OAuth proxy uses.
When checking if an account has privileges over a particular
namespace, namespaces are treated as namespaced objects, meaning
the SAR requires a `namespace` field.

fixes: https://github.com/openshift/telemeter/issues/123

cc @s-urbaniak @jfchevrette 