### PR TITLE
Add storage to prometheus

### DIFF
--- a/jsonnet/telemeter/prometheus/kubernetes.libsonnet
+++ b/jsonnet/telemeter/prometheus/kubernetes.libsonnet
@@ -216,6 +216,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       local container = k.core.v1.pod.mixin.spec.containersType;
       local resourceRequirements = container.mixin.resourcesType;
       local selector = k.apps.v1beta2.deployment.mixin.spec.selectorType;
+      local pvc = k.core.v1.persistentVolumeClaim;
 
       local resources =
         resourceRequirements.new() +
@@ -252,6 +253,13 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
             'k8s-app': 'telemeter-server',
             endpoint: 'federate',
           }),
+          storage: {
+            volumeClaimTemplate:
+              pvc.new() +
+              pvc.mixin.spec.withAccessModes('ReadWriteOnce') +
+              pvc.mixin.spec.resources.withRequests({storage: '500Gi'}) +
+              pvc.mixin.spec.withStorageClassName('gp2-encrypted'),
+          },
           listenLocal: true,
           containers: [
             {

--- a/manifests/prometheus/list.yaml
+++ b/manifests/prometheus/list.yaml
@@ -116,6 +116,17 @@ objects:
       matchLabels:
         endpoint: federate
         k8s-app: telemeter-server
+    storage:
+      volumeClaimTemplate:
+        apiVersion: v1
+        kind: PersistentVolumeClaim
+        spec:
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: 500Gi
+          storageClassName: gp2-encrypted
     version: ${PROMETHEUS_IMAGE_TAG}
 - apiVersion: v1
   data:

--- a/manifests/prometheus/prometheus.yaml
+++ b/manifests/prometheus/prometheus.yaml
@@ -59,4 +59,15 @@ spec:
     matchLabels:
       endpoint: federate
       k8s-app: telemeter-server
+  storage:
+    volumeClaimTemplate:
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 500Gi
+        storageClassName: gp2-encrypted
   version: v2.3.2


### PR DESCRIPTION
This adds 500Gi PVCs to prometheus replicas.

Commit contains both the jsonnet changes and the resulting manifest changes