### PR TITLE
 jsonnet: take some values from spec

### DIFF
--- a/manifests/client/deployment.yaml
+++ b/manifests/client/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       - command:
         - /usr/bin/telemeter-client
         - --id=$(ID)
-        - --from=https://prometheus-k8s.openshift-monitoring.svc:9091
+        - --from=$(FROM)
         - --from-ca-file=/etc/serving-certs-ca-bundle/service-ca.crt
         - --from-token-file=/var/run/secrets/kubernetes.io/serviceaccount/token
         - --to=$(TO)
@@ -30,20 +30,13 @@ spec:
         - --anonymize-labels=$(ANONYMIZE_LABELS)
         env:
         - name: ANONYMIZE_LABELS
-          valueFrom:
-            secretKeyRef:
-              key: anonymizeLabels
-              name: telemeter-client
+          value: ""
+        - name: FROM
+          value: https://prometheus-k8s.openshift-monitoring.svc:9091
         - name: ID
-          valueFrom:
-            secretKeyRef:
-              key: id
-              name: telemeter-client
+          value: ""
         - name: TO
-          valueFrom:
-            secretKeyRef:
-              key: to
-              name: telemeter-client
+          value: https://infogw.api.openshift.com
         image: quay.io/openshift/origin-telemeter:v4.0
         name: telemeter-client
         ports:

--- a/manifests/client/secret.yaml
+++ b/manifests/client/secret.yaml
@@ -1,9 +1,7 @@
 apiVersion: v1
 data:
-  anonymizeLabels: ""
   match-rules: e19fbmFtZV9fPSJ1cCJ9CntfX25hbWVfXz0iY2x1c3Rlcl92ZXJzaW9uIn0Ke19fbmFtZV9fPSJjbHVzdGVyX29wZXJhdG9yX3VwIn0Ke19fbmFtZV9fPSJjbHVzdGVyX29wZXJhdG9yX2NvbmRpdGlvbnMifQp7X19uYW1lX189ImNsdXN0ZXJfdmVyc2lvbl9wYXlsb2FkIn0Ke19fbmFtZV9fPSJjbHVzdGVyX3ZlcnNpb25fcGF5bG9hZF9lcnJvcnMifQp7X19uYW1lX189Im1hY2hpbmVfY3B1X2NvcmVzIn0Ke19fbmFtZV9fPSJtYWNoaW5lX21lbW9yeV9ieXRlcyJ9CntfX25hbWVfXz0iZXRjZF9vYmplY3RfY291bnRzIn0Ke19fbmFtZV9fPSJBTEVSVFMiLGFsZXJ0c3RhdGU9ImZpcmluZyJ9
   salt: ""
-  to: aHR0cHM6Ly9pbmZvZ3cuYXBpLm9wZW5zaGlmdC5jb20=
   token: ""
 kind: Secret
 metadata:


### PR DESCRIPTION
This is the first part of fixing reloading of certain Telemeter client fields.
The next part will be a change in Cluster Monitoring Operator.
cc @s-urbaniak 

The Telemeter client should take some non-sensitive values directly from
the pod spec rather than from the secret. This way, if the values in the
pod spec are modified by the cluster-monitoring-operator, the pod will
be rolled. Otherwise, the operator would have to check for a changed
secret and then scale the pod down and up.

Note that introducing a config-reloader would not help in this case as
the values are taken from command-line arguments that are never re-read,
rather than read from files.