### PR TITLE
Add prometheus retention set to 15d

### DIFF
--- a/jsonnet/telemeter/prometheus/kubernetes.libsonnet
+++ b/jsonnet/telemeter/prometheus/kubernetes.libsonnet
@@ -240,6 +240,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
           serviceAccountName: 'prometheus-' + $._config.prometheus.name,
           nodeSelector: { 'beta.kubernetes.io/os': 'linux' },
           resources: resources,
+          retention: '15d',
           ruleSelector: selector.withMatchLabels({
             role: 'alert-rules',
             prometheus: $._config.prometheus.name,

--- a/manifests/prometheus/list.yaml
+++ b/manifests/prometheus/list.yaml
@@ -103,6 +103,7 @@ objects:
     resources:
       requests:
         memory: 400Mi
+    retention: 15d
     ruleSelector:
       matchLabels:
         prometheus: telemeter

--- a/manifests/prometheus/prometheus.yaml
+++ b/manifests/prometheus/prometheus.yaml
@@ -45,6 +45,7 @@ spec:
   resources:
     requests:
       memory: 400Mi
+  retention: 15d
   ruleSelector:
     matchLabels:
       prometheus: telemeter


### PR DESCRIPTION
Prometheus manifest is missing retention. 

15d is the current expectation since that is what we're running at the moment. I assume it was added manually on the running instance and that change was never propagated upstream.
