### PR TITLE
Add SRE team to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,6 +4,16 @@ reviewers:
 - squat
 - s-urbaniak
 - smarterclayton
+- aditya-konarde
+- jfchevrette
+- jmelis
+- jakedt
+- jzelinskie
+- maorfr
+- mmclanerh
+- pbergene
+- riuvshin
+- skryzhny 
 
 approvers:
 - brancz
@@ -11,3 +21,13 @@ approvers:
 - squat
 - s-urbaniak
 - smarterclayton
+- aditya-konarde
+- jfchevrette
+- jmelis
+- jakedt
+- jzelinskie
+- maorfr
+- mmclanerh
+- pbergene
+- riuvshin
+- skryzhny


### PR DESCRIPTION
As discussed with @s-urbaniak and @squat ; The SRE team needs access to the repo, in case of any emergency hotfixes, and for quicker turnaround on collaborations, among other things.