### PR TITLE
add metrics, use correct metric type in store

### DIFF
--- a/pkg/store/instrumented/instrumented.go
+++ b/pkg/store/instrumented/instrumented.go
@@ -9,25 +9,25 @@ import (
 )
 
 var (
-	metricSamples = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "telemeter_server_samples",
+	metricSamplesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "telemeter_server_samples_total",
 		Help: "Tracks the number of samples processed by this server.",
 	}, []string{"phase"})
 )
 
 func init() {
-	prometheus.MustRegister(metricSamples)
+	prometheus.MustRegister(metricSamplesTotal)
 }
 
 type instrumented struct {
-	target store.Store
-	gauge  prometheus.Gauge
+	target  store.Store
+	counter prometheus.Counter
 }
 
-func New(target store.Store, labelValues ...string) *instrumented {
+func New(target store.Store, phase string) *instrumented {
 	return &instrumented{
-		target: target,
-		gauge:  metricSamples.WithLabelValues(labelValues...),
+		target:  target,
+		counter: metricSamplesTotal.WithLabelValues(phase),
 	}
 }
 
@@ -46,7 +46,7 @@ func (s *instrumented) WriteMetrics(ctx context.Context, p *store.PartitionedMet
 		}
 	}
 
-	s.gauge.Add(float64(metricfamily.MetricsCount(p.Families)))
+	s.counter.Add(float64(metricfamily.MetricsCount(p.Families)))
 
 	return nil
 }

--- a/pkg/store/memstore/memstore.go
+++ b/pkg/store/memstore/memstore.go
@@ -8,8 +8,32 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/openshift/telemeter/pkg/store"
+	"github.com/prometheus/client_golang/prometheus"
 	clientmodel "github.com/prometheus/client_model/go"
 )
+
+var (
+	families = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "telemeter_memory_store_families",
+		Help: "Tracks the current amount of families for a given partition.",
+	}, []string{"partition"})
+
+	partititions = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "telemeter_memory_store_partitions",
+		Help: "Tracks the current amount of stored partitions.",
+	})
+
+	cleanupCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "telemeter_memory_store_cleanup_count",
+		Help: "Tracks the total amount of cleanups.",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(partititions)
+	prometheus.MustRegister(cleanupCount)
+	prometheus.MustRegister(families)
+}
 
 type clusterMetricSlice struct {
 	newest   int64
@@ -56,9 +80,13 @@ func (s *memoryStore) cleanup(now time.Time) {
 		ttlTimestampMs := now.Add(-s.ttl).UnixNano() / int64(time.Millisecond)
 
 		if slice.newest < ttlTimestampMs {
+			families.WithLabelValues(partitionKey).Set(0)
 			delete(s.store, partitionKey)
 		}
 	}
+
+	cleanupCount.Inc()
+	partititions.Set(float64(len(s.store)))
 }
 
 func (s *memoryStore) ReadMetrics(ctx context.Context, minTimestampMs int64) ([]*store.PartitionedMetrics, error) {
@@ -113,6 +141,9 @@ func (s *memoryStore) WriteMetrics(ctx context.Context, p *store.PartitionedMetr
 	}
 
 	m.families = p.Families
+
+	partititions.Set(float64(len(s.store)))
+	families.WithLabelValues(p.PartitionKey).Set(float64(len(p.Families)))
 
 	return nil
 }


### PR DESCRIPTION
This adds some metrics to the memory for debugging potential leaks.

Currently, we are using a gauge instead of a counter for counting the total
amount of stored metrics.

This fixes it.

cc @squat @jfchevrette