### PR TITLE
cmd/telemeter-server: start memory store cleaner

### DIFF
--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -375,8 +375,11 @@ func (o *Options) Run() error {
 	auth := jwt.NewAuthorizeClusterHandler(o.PartitionKey, o.TokenExpireSeconds, signer, o.RequiredLabels, clusterAuth)
 	validator := validate.New(o.PartitionKey, o.LimitBytes, 24*time.Hour)
 
+	ms := memstore.New(o.TTL)
+	ms.StartCleaner(ctx, time.Minute)
+
 	// Create a rate-limited store with a memory-store as its persistence.
-	var store store.Store = ratelimited.New(o.Ratelimit, instrumented.New(memstore.New(o.TTL), "memory"))
+	var store store.Store = ratelimited.New(o.Ratelimit, instrumented.New(ms, "memory"))
 
 	if len(o.ListenCluster) > 0 {
 		c := cluster.NewDynamic(o.Name, store)


### PR DESCRIPTION
Currently the cleaner is not started, causing possible memory leaks.

This fixes it.

cc @squat