### PR TITLE
jsonnet/telemeter: Pin Prometheus Operator version

### DIFF
--- a/jsonnet/telemeter/jsonnetfile.json
+++ b/jsonnet/telemeter/jsonnetfile.json
@@ -18,7 +18,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "master"
+            "version": "v0.29.0"
         }
     ]
 }


### PR DESCRIPTION
This patch pins the Prometheus Operator version specified in the
`jsonnet/telemeter/jsonnetfile.json` file to `v0.29.0` instead of
`master`.

Both kube-prometheus [1] as well as telemeter-client [2] vendor
prometheus-operator [3] in their `jsonnetfile.json`. In addition both
kube-prometheus as well as telemeter-client are vendored by the
cluster-monitoring-operator [4]. kube-prometheus imports
prometheus-operator at reference `v0.29.0`, telemeter-client imports
prometheus-operator at reference `master`. This results in a version
conflict in the cluster-monitoring-operator.

[1] https://github.com/coreos/prometheus-operator/blob/master/contrib/kube-prometheus/jsonnet/kube-prometheus/jsonnetfile.json#L41

[2] https://github.com/openshift/telemeter/blob/master/jsonnet/telemeter/jsonnetfile.json#L21

[3] https://github.com/coreos/prometheus-operator

[4] https://github.com/openshift/cluster-monitoring-operator/blob/master/jsonnet/jsonnetfile.json