### PR TITLE
pkg/metricfamily: add elide transformer

### DIFF
--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -124,6 +124,7 @@ func main() {
 	cmd.Flags().StringSliceVar(&opt.RequiredLabelFlag, "required-label", opt.RequiredLabelFlag, "Labels that must be present on each incoming metric, in key=value form.")
 	cmd.Flags().StringArrayVar(&opt.Whitelist, "whitelist", opt.Whitelist, "Allowed rules for incoming metrics. If one of these rules is not matched, the metric is dropped.")
 	cmd.Flags().StringVar(&opt.WhitelistFile, "whitelist-file", opt.WhitelistFile, "A file of allowed rules for incoming metrics. If one of these rules is not matched, the metric is dropped; one label key per line.")
+	cmd.Flags().StringArrayVar(&opt.ElideLabels, "elide-label", opt.ElideLabels, "A list of labels to be elided from incoming metrics.")
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
@@ -161,6 +162,7 @@ type Options struct {
 	RequiredLabelFlag []string
 	RequiredLabels    map[string]string
 	Whitelist         []string
+	ElideLabels       []string
 	WhitelistFile     string
 
 	TTL       time.Duration
@@ -421,6 +423,7 @@ func (o *Options) Run() error {
 	if len(o.Labels) > 0 {
 		transforms.With(metricfamily.NewLabel(o.Labels, nil))
 	}
+	transforms.With(metricfamily.NewElide(o.ElideLabels...))
 
 	server := httpserver.New(store, validator, transforms, o.TTL)
 

--- a/pkg/metricfamily/elide.go
+++ b/pkg/metricfamily/elide.go
@@ -1,0 +1,40 @@
+package metricfamily
+
+import (
+	prom "github.com/prometheus/client_model/go"
+)
+
+type elide struct {
+	labelSet map[string]struct{}
+}
+
+// NewElide creates a new elide transformer for the given metrics.
+func NewElide(labels ...string) *elide {
+	labelSet := make(map[string]struct{})
+	for i := range labels {
+		labelSet[labels[i]] = struct{}{}
+	}
+
+	return &elide{labelSet}
+}
+
+// Transform filters label pairs in the given metrics family,
+// eliding labels.
+func (t *elide) Transform(family *prom.MetricFamily) (bool, error) {
+	if family == nil || len(family.Metric) == 0 {
+		return true, nil
+	}
+
+	for i := range family.Metric {
+		var filtered []*prom.LabelPair
+		for j := range family.Metric[i].Label {
+			if _, elide := t.labelSet[family.Metric[i].Label[j].GetName()]; elide {
+				continue
+			}
+			filtered = append(filtered, family.Metric[i].Label[j])
+		}
+		family.Metric[i].Label = filtered
+	}
+
+	return true, nil
+}

--- a/pkg/metricfamily/elide_test.go
+++ b/pkg/metricfamily/elide_test.go
@@ -1,0 +1,217 @@
+package metricfamily
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	clientmodel "github.com/prometheus/client_model/go"
+	prom "github.com/prometheus/client_model/go"
+)
+
+func TestElide(t *testing.T) {
+	family := func(metrics ...*prom.Metric) *prom.MetricFamily {
+		families := &prom.MetricFamily{Name: proto.String("test")}
+		families.Metric = append(families.Metric, metrics...)
+		return families
+	}
+
+	type checkFunc func(family *prom.MetricFamily, ok bool, err error) error
+
+	isOK := func(want bool) checkFunc {
+		return func(_ *clientmodel.MetricFamily, got bool, _ error) error {
+			if want != got {
+				return fmt.Errorf("want ok %t, got %t", want, got)
+			}
+			return nil
+		}
+	}
+
+	hasErr := func(want error) checkFunc {
+		return func(_ *clientmodel.MetricFamily, _ bool, got error) error {
+			if want != got {
+				return fmt.Errorf("want err %v, got %v", want, got)
+			}
+			return nil
+		}
+	}
+
+	metricIsNil := func(want bool) checkFunc {
+		return func(m *clientmodel.MetricFamily, _ bool, _ error) error {
+			if got := m == nil; want != got {
+				return fmt.Errorf("want metric to be nil=%t, got %t", want, got)
+			}
+			return nil
+		}
+	}
+
+	hasMetricCount := func(want int) checkFunc {
+		return func(m *clientmodel.MetricFamily, _ bool, _ error) error {
+			if got := len(m.Metric); want != got {
+				return fmt.Errorf("want len(m.Metric)=%v, got %v", want, got)
+			}
+			return nil
+		}
+	}
+
+	hasLabelCount := func(want ...int) checkFunc {
+		return func(family *clientmodel.MetricFamily, _ bool, _ error) error {
+			for i := range family.Metric {
+				if got := len(family.Metric[i].Label); got != want[i] {
+					return fmt.Errorf(
+						"want len(m.Metric[%v].Label)=%v, got %v",
+						i, want[i], got)
+				}
+			}
+			return nil
+		}
+	}
+
+	hasLabels := func(want bool, labels ...string) checkFunc {
+		return func(family *prom.MetricFamily, _ bool, _ error) error {
+			labelSet := make(map[string]struct{})
+			for i := range family.Metric {
+				for j := range family.Metric[i].Label {
+					labelSet[family.Metric[i].Label[j].GetName()] = struct{}{}
+				}
+			}
+
+			for _, label := range labels {
+				if _, got := labelSet[label]; want != got {
+					wants := "present"
+					if !want {
+						wants = "not present"
+					}
+
+					gots := "is"
+					if !got {
+						gots = "isn't"
+					}
+
+					return fmt.Errorf(
+						"want label %q be %s in metrics, but it %s",
+						label, wants, gots,
+					)
+				}
+			}
+
+			return nil
+		}
+	}
+
+	metricWithLabels := func(labels ...string) *prom.Metric {
+		var labelPairs []*prom.LabelPair
+		for _, l := range labels {
+			labelPairs = append(labelPairs, &prom.LabelPair{Name: proto.String(l)})
+		}
+		return &prom.Metric{Label: labelPairs}
+	}
+
+	for _, tc := range []struct {
+		family *prom.MetricFamily
+		elide  *elide
+		name   string
+		checks []checkFunc
+	}{
+		{
+			name:   "nil family",
+			family: nil,
+			elide:  NewElide("elide"),
+			checks: []checkFunc{
+				isOK(true),
+				hasErr(nil),
+				metricIsNil(true),
+			},
+		},
+		{
+			name:   "empty family",
+			family: family(),
+			elide:  NewElide("elide"),
+			checks: []checkFunc{
+				isOK(true),
+				hasErr(nil),
+				hasMetricCount(0),
+			},
+		},
+		{
+			name:   "one elide one retain",
+			family: family(metricWithLabels("retain", "elide")),
+			elide:  NewElide("elide"),
+			checks: []checkFunc{
+				isOK(true),
+				hasErr(nil),
+				hasMetricCount(1),
+				hasLabelCount(1),
+				hasLabels(false, "elide"),
+				hasLabels(true, "retain"),
+			},
+		},
+		{
+			name:   "no match",
+			family: family(metricWithLabels("retain")),
+			elide:  NewElide("elide"),
+			checks: []checkFunc{
+				isOK(true),
+				hasErr(nil),
+				hasMetricCount(1),
+				hasLabelCount(1),
+				hasLabels(false, "elide"),
+				hasLabels(true, "retain"),
+			},
+		},
+		{
+			name:   "single match",
+			family: family(metricWithLabels("elide")),
+			elide:  NewElide("elide"),
+			checks: []checkFunc{
+				isOK(true),
+				hasErr(nil),
+				hasMetricCount(1),
+				hasLabelCount(0),
+				hasLabels(false, "elide"),
+			},
+		},
+		{
+			name: "multiple retains, multiple elides",
+			family: family(
+				metricWithLabels("elide1", "elide2", "retain1", "retain2"),
+			),
+			elide: NewElide("elide1", "elide2"),
+			checks: []checkFunc{
+				isOK(true),
+				hasErr(nil),
+				hasMetricCount(1),
+				hasLabelCount(2),
+				hasLabels(false, "elide1"),
+				hasLabels(false, "elide2"),
+				hasLabels(true, "retain1"),
+				hasLabels(true, "retain2"),
+			},
+		},
+		{
+			name: "empty elider",
+			family: family(
+				metricWithLabels("retain1", "retain2"),
+			),
+			elide: NewElide(),
+			checks: []checkFunc{
+				isOK(true),
+				hasErr(nil),
+				hasMetricCount(1),
+				hasLabelCount(2),
+				hasLabels(true, "retain1"),
+				hasLabels(true, "retain2"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, err := tc.elide.Transform(tc.family)
+
+			for _, check := range tc.checks {
+				if err := check(tc.family, ok, err); err != nil {
+					t.Error(err)
+				}
+			}
+		})
+	}
+}

--- a/test/prom-local.conf
+++ b/test/prom-local.conf
@@ -26,3 +26,6 @@ scrape_configs:
     - targets:
       - 'localhost:9004'
       - 'localhost:9014'
+
+      labels:
+        _elide: 'integration-test'


### PR DESCRIPTION
This adds the label eliding feature.
A separate PR follows which enables this feature in the deployment.

Fixes partially MON-516