### PR TITLE
pkg/forwarder: fix match flag

### DIFF
--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -192,13 +192,13 @@ func New(cfg Config) (*Worker, error) {
 	w.transformer = transformer
 
 	// Configure the matching rules.
-	var rules []string
+	rules := cfg.Rules
 	if len(cfg.RulesFile) > 0 {
 		data, err := ioutil.ReadFile(cfg.RulesFile)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read match-file: %v", err)
 		}
-		rules = append(cfg.Rules, strings.Split(string(data), "\n")...)
+		rules = append(rules, strings.Split(string(data), "\n")...)
 	}
 	for i := 0; i < len(rules); {
 		s := strings.TrimSpace(rules[i])


### PR DESCRIPTION
When a `--match` flag is passed without also specifying a
`--match-file`, the match rules are ignored. This fixes it. Notable, the
`./test/integration.sh` test included both flags, so we never hit the
error scenario.

This error is blocking getting the new infra metrics working.
To get the new metrics working in production, we need to bump
the jsonnet telemeter dep in CMO, but that changes the flags to
telemeter client from `--match-file` to `--match` so we will see the log
```
2019/03/25 16:29:32 warning: no metrics to send, doing nothing
```

@s-urbaniak 