### PR TITLE
pkg/authorize/tollbooth: handle 404 - cluster not found

### DIFF
--- a/pkg/authorize/tollbooth/tollbooth.go
+++ b/pkg/authorize/tollbooth/tollbooth.go
@@ -72,6 +72,8 @@ func (a *authorizer) AuthorizeCluster(token, cluster string) (string, error) {
 		return "", errWithCode{error: fmt.Errorf("rate limited, please try again later"), code: http.StatusTooManyRequests}
 	case http.StatusConflict:
 		return "", errWithCode{error: fmt.Errorf("the provided cluster identifier is already in use under a different account or is not sufficiently random"), code: http.StatusConflict}
+	case http.StatusNotFound:
+		return "", errWithCode{error: fmt.Errorf("not found"), code: http.StatusNotFound}
 	case http.StatusOK, http.StatusCreated:
 		// allowed
 	default:


### PR DESCRIPTION
Currently, if clusters are not found, this is propagated via a 500 status code.
This fixes it by handling a 404 code explicitely.

Depends on https://gitlab.cee.redhat.com/service/uhc-account-manager/merge_requests/388