### PR TITLE
authorize/jwt/handler: log authorize failures for >= 500

### DIFF
--- a/pkg/authorize/jwt/handler.go
+++ b/pkg/authorize/jwt/handler.go
@@ -77,7 +77,9 @@ func (a *authorizeClusterHandler) ServeHTTP(w http.ResponseWriter, req *http.Req
 		}
 
 		if scerr, ok := err.(statusCodeErr); ok {
-			log.Printf("error: unable to authorize request: %v", scerr)
+			if scerr.HTTPStatusCode() >= http.StatusInternalServerError {
+				log.Printf("error: unable to authorize request: %v", scerr)
+			}
 			if scerr.HTTPStatusCode() == http.StatusTooManyRequests {
 				w.Header().Set("Retry-After", "300")
 			}


### PR DESCRIPTION
Currently we still log all authorize failures, spamming the telemeter server logs.

This fixes it by reducing the logging to actionable errors, namely with http status code >= 500.


cc @squat @aditya-konarde: I recognized in production, that we indeed still log authorize failure, even if clusters are unknown. This should lower the noise on telemeter server logs in production.