### PR TITLE
 jsonnet: prometheus route balance source IP

### DIFF
--- a/jsonnet/telemeter/prometheus/kubernetes.libsonnet
+++ b/jsonnet/telemeter/prometheus/kubernetes.libsonnet
@@ -52,6 +52,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
         annotations: {
           'kubernetes.io/tls-acme': 'true',
           'kubernetes.io/tls-acme-secretname': 'prometheus-%s-acme' % $._config.prometheus.name,
+          'haproxy.router.openshift.io/balance': 'source',
         },
         name: 'prometheus-' + $._config.prometheus.name,
         namespace: $._config.namespace,

--- a/manifests/prometheus/list.yaml
+++ b/manifests/prometheus/list.yaml
@@ -202,6 +202,7 @@ objects:
   kind: Route
   metadata:
     annotations:
+      haproxy.router.openshift.io/balance: source
       kubernetes.io/tls-acme: "true"
       kubernetes.io/tls-acme-secretname: prometheus-telemeter-acme
     name: prometheus-telemeter

--- a/manifests/prometheus/route.yaml
+++ b/manifests/prometheus/route.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Route
 metadata:
   annotations:
+    haproxy.router.openshift.io/balance: source
     kubernetes.io/tls-acme: "true"
     kubernetes.io/tls-acme-secretname: prometheus-telemeter-acme
   name: prometheus-telemeter


### PR DESCRIPTION
This commit changes the Telemeter Prometheus Route object to use the
client's source IP as the load balancing criteria. This will ensure that
all requests coming from the same client end up at the same Pod. #145
was intended to implement this feature but came up short because
OpenShift Routes do not connect directly to Services but rather to their
underlying Endpoints.

cc @jfchevrette @s-urbaniak 