### PR TITLE
Remove two major sources of contention from telemeter

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -100,7 +100,7 @@ type DynamicCluster struct {
 	// and is processed in the #handleMessage function.
 	queue chan ([]byte)
 
-	lock        sync.Mutex
+	lock        sync.RWMutex
 	updated     time.Time
 	ring        *hashring.HashRing
 	problematic map[string]*nodeData
@@ -124,6 +124,18 @@ func NewDynamic(name string, store store.Store) *DynamicCluster {
 func (c *DynamicCluster) Start(ml memberlister, ctx context.Context) {
 	c.ml = ml
 	c.ctx = ctx
+
+	go func() {
+		defer func() {
+			if err := recover(); err != nil {
+				log.Fatalf("Unable to refresh the hash ring: %v", err)
+			}
+		}()
+		for {
+			c.refreshRing()
+			time.Sleep(time.Minute)
+		}
+	}()
 
 	go func() {
 		for {
@@ -173,25 +185,21 @@ func (c *DynamicCluster) debugInfo() debugInfo {
 	return info
 }
 
+// refreshRing is invoked periodically to update the hash ring
 func (c *DynamicCluster) refreshRing() {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	if !c.updated.IsZero() && c.updated.Before(time.Now().Add(-time.Minute)) {
-		return
-	}
-
 	members := make([]string, 0, c.ml.NumMembers())
 	for _, n := range c.ml.Members() {
 		members = append(members, n.Name)
 	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	c.ring = hashring.New(members)
 }
 
 func (c *DynamicCluster) getNodeForKey(partitionKey string) (string, bool) {
-	c.refreshRing()
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 	return c.ring.GetNode(partitionKey)
 }
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -101,7 +101,6 @@ type DynamicCluster struct {
 	queue chan ([]byte)
 
 	lock        sync.RWMutex
-	updated     time.Time
 	ring        *hashring.HashRing
 	problematic map[string]*nodeData
 }

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -362,6 +362,7 @@ func TestWriteMetrics(t *testing.T) {
 			if tc.initDynamicCluster != nil {
 				tc.initDynamicCluster(dc)
 			}
+			dc.refreshRing()
 
 			if err := tc.writeMetricsCheck(dc.WriteMetrics(ctx, &store.PartitionedMetrics{
 				PartitionKey: tc.partitionKey,

--- a/pkg/http/routes.go
+++ b/pkg/http/routes.go
@@ -13,6 +13,7 @@ func DebugRoutes(mux *http.ServeMux) *http.ServeMux {
 	mux.HandleFunc("/debug/pprof/", pprof.Index)
 	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
 	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.Handle("/debug/pprof/block", pprof.Handler("block"))
 	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	return mux


### PR DESCRIPTION
While running local workloads I tested for contention between locks.
There were two obvious contention points that could be removed easily
without risk:


   store: Don't hold the mutex while writing metrics

   We were holding the limiter lock while accessing the store, which is not
   necessary because the store is already safe and the limiter is already a
   synchronization point. Switch the lock to guard only the map.

   Removes a significant source of contention from the path.

and

   cluster: Avoid contention on write lock

   A significant source of contentions in the block profile was the 
   refreshRing call. Since reads dominate writes (100:1 or more) we should us
   a RWMutex. Also, we don't need to refresh inline, so switch to a background
   loop for refreshing.

   Removes a source of contention when handling incoming requests.

To test locally you need to set `runtime.SetBlockProfileRate(>0)` and then
use `go tool pprof -http : http://localhost:9004/debug/pprof/block` after
a few minutes of stress testing.