### PR TITLE
client: Set priority class

### DIFF
--- a/jsonnet/telemeter/client/kubernetes.libsonnet
+++ b/jsonnet/telemeter/client/kubernetes.libsonnet
@@ -156,6 +156,7 @@ local securePort = 8443;
       deployment.mixin.metadata.withLabels(podLabels) +
       deployment.mixin.spec.selector.withMatchLabels(podLabels) +
       deployment.mixin.spec.template.spec.withServiceAccountName('telemeter-client') +
+      deployment.mixin.spec.template.spec.withPriorityClassName('system-cluster-critical') +
       deployment.mixin.spec.template.spec.withVolumes([sccabVolume, secretVolume, tlsVolume]),
 
     secret:

--- a/manifests/client/deployment.yaml
+++ b/manifests/client/deployment.yaml
@@ -99,6 +99,7 @@ spec:
         - mountPath: /etc/tls/private
           name: telemeter-client-tls
           readOnly: false
+      priorityClassName: system-cluster-critical
       serviceAccountName: telemeter-client
       volumes:
       - configMap:


### PR DESCRIPTION
All cluster components are supposed to have the
"system-cluster-critical" priority class.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1624253 for telemeter client.

@squat @s-urbaniak @metalmatze @mxinden @paulfantom 