### PR TITLE
Update server & prometheus templates default resources

### DIFF
--- a/jsonnet/telemeter/lib/list.libsonnet
+++ b/jsonnet/telemeter/lib/list.libsonnet
@@ -43,10 +43,10 @@
       for o in super.objects
     ],
     parameters+: [
-      { name: std.asciiUpper(varContainerName)+'_CPU_REQUEST', value: if std.objectHas(requests, 'cpu') then requests.cpu else "0" },
-      { name: std.asciiUpper(varContainerName)+'_CPU_LIMIT', value: if std.objectHas(limits, 'cpu') then limits.cpu else "0" },
-      { name: std.asciiUpper(varContainerName)+'_MEMORY_REQUEST', value: if std.objectHas(requests, 'memory') then requests.memory else "0" },
-      { name: std.asciiUpper(varContainerName)+'_MEMORY_LIMIT', value: if std.objectHas(limits, 'memory') then limits.memory else "0" },
+      { name: std.asciiUpper(varContainerName)+'_CPU_REQUEST', value: if std.objectHas(requests, 'cpu') then requests.cpu else "100m" },
+      { name: std.asciiUpper(varContainerName)+'_CPU_LIMIT', value: if std.objectHas(limits, 'cpu') then limits.cpu else "1" },
+      { name: std.asciiUpper(varContainerName)+'_MEMORY_REQUEST', value: if std.objectHas(requests, 'memory') then requests.memory else "500Mi" },
+      { name: std.asciiUpper(varContainerName)+'_MEMORY_LIMIT', value: if std.objectHas(limits, 'memory') then limits.memory else "1Gi" },
     ],
   },
 

--- a/manifests/server/list.yaml
+++ b/manifests/server/list.yaml
@@ -221,10 +221,10 @@ parameters:
 - name: IMAGE_TAG
   value: v4.0
 - name: TELEMETER_SERVER_CPU_REQUEST
-  value: "0"
+  value: 100m
 - name: TELEMETER_SERVER_CPU_LIMIT
-  value: "0"
+  value: "1"
 - name: TELEMETER_SERVER_MEMORY_REQUEST
-  value: "0"
+  value: 500Mi
 - name: TELEMETER_SERVER_MEMORY_LIMIT
-  value: "0"
+  value: 1Gi


### PR DESCRIPTION
This changes the templates default values from 0 to sane(er) defaults.

This work around an issue we had where openshift (oc client?) considers `0` (request) to be lower than a value like `400Mi` (limit) (set by prometheus-operator) and refuses to deploy the pod. Setting actual values will avoid this corner case.