### PR TITLE
jsonnet: add nodeSelector to telemeter client

### DIFF
--- a/jsonnet/telemeter/client/kubernetes.libsonnet
+++ b/jsonnet/telemeter/client/kubernetes.libsonnet
@@ -157,6 +157,7 @@ local securePort = 8443;
       deployment.mixin.spec.selector.withMatchLabels(podLabels) +
       deployment.mixin.spec.template.spec.withServiceAccountName('telemeter-client') +
       deployment.mixin.spec.template.spec.withPriorityClassName('system-cluster-critical') +
+      deployment.mixin.spec.template.spec.withNodeSelector({'beta.kubernetes.io/os': 'linux'}) +
       deployment.mixin.spec.template.spec.withVolumes([sccabVolume, secretVolume, tlsVolume]),
 
     secret:

--- a/manifests/client/deployment.yaml
+++ b/manifests/client/deployment.yaml
@@ -97,6 +97,8 @@ spec:
         - mountPath: /etc/tls/private
           name: telemeter-client-tls
           readOnly: false
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: telemeter-client
       volumes:


### PR DESCRIPTION
Specify telemeter client to be scheduled only on linux nodes.

/cc @brancz @squat @s-urbaniak 