### PR TITLE
pkg/metricsclient: fix data race when creating error message while closing context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,8 @@ $(JB_BIN):
 	go get -u github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
 
 $(JSONNET_BIN):
-	go get -u github.com/google/go-jsonnet/cmd/jsonnet
+	go get -u -d github.com/google/go-jsonnet/cmd/jsonnet
+	cd $(GOPATH)/src/github.com/google/go-jsonnet && git checkout v0.12.1 && git submodule update && go install -a ./jsonnet
 
 $(GOLANGCI_LINT_BIN):
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(BIN) v1.10.2


### PR DESCRIPTION
Currently function `withCancel` starts a goroutine which writes to `err` variable. Unfortunately in case where context is closed we want to write to the same variable before goroutine finishes. This causes a data race.

Fix ensures that we are only writing to `err` in goroutine and after it finishes we are reading `err` value.

Problem was observed in https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_telemeter/134/pull-ci-openshift-telemeter-master-unit/220

Ticket: MON-594

/CC: @metalmatze @s-urbaniak @squat 