### PR TITLE
Bug 1707681: pkg/forwarder: fix ever growing URI

### DIFF
--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -276,6 +276,9 @@ func (w *Worker) forward(ctx context.Context) error {
 
 	// Load the match rules each time.
 	from := w.from
+
+	// reset query from last invocation, otherwise match rules will be appended
+	w.from.RawQuery = ""
 	v := from.Query()
 	for _, rule := range w.rules {
 		v.Add("match[]", rule)


### PR DESCRIPTION
Currently, match rules will be appended to the query towards
Prometheus because the previous query is being reused.

This fixes it by resetting the raw query, before encoding it again

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1707681