### PR TITLE
prometheus-telemeter: Set sessionAffinity to ClientIP

### DIFF
--- a/deploy/prometheus.yaml
+++ b/deploy/prometheus.yaml
@@ -16,6 +16,7 @@ items:
     - name: http
       port: 80
       targetPort: 9090
+    sessionAffinity: ClientIP
 - kind: StatefulSet
   apiVersion: apps/v1
   metadata:


### PR DESCRIPTION
This is so that any client within the cluster talking to prometheus gets to exactly the same server as long as the server is up.