### PR TITLE
Bump Prometheus Operator to v0.30.0 in jsonnet

### DIFF
--- a/jsonnet/telemeter/jsonnetfile.json
+++ b/jsonnet/telemeter/jsonnetfile.json
@@ -18,7 +18,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "v0.29.0"
+            "version": "v0.30.0"
         }
     ]
 }


### PR DESCRIPTION
We want to pin kube-prometheus in the cluster-monitoring-operator to use the stable `release-0.1` branch. That branch of kube-proemtheus however already uses v0.30.0 of the Prometheus Operator and therefore this needs to be bump in here, because jsonnet-bundler cannot handle (and shouldn't) multiple version in the same repo.

/cc @s-urbaniak @squat 