### PR TITLE
pkg/store/ratelimited: log offending key

### DIFF
--- a/pkg/http/server/server.go
+++ b/pkg/http/server/server.go
@@ -128,7 +128,7 @@ func (s *Server) Post(w http.ResponseWriter, req *http.Request) {
 		switch err {
 		case nil:
 			break
-		case ratelimited.ErrWriteLimitReached:
+		case ratelimited.ErrWriteLimitReached(partitionKey):
 			http.Error(w, err.Error(), http.StatusTooManyRequests)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/store/ratelimited/ratelimited_test.go
+++ b/pkg/store/ratelimited/ratelimited_test.go
@@ -47,13 +47,13 @@ func TestWriteMetrics(t *testing.T) {
 			name:        "write after 1 second fails",
 			advance:     time.Second,
 			metrics:     &store.PartitionedMetrics{PartitionKey: "a"},
-			expectedErr: ErrWriteLimitReached,
+			expectedErr: ErrWriteLimitReached("a"),
 		},
 		{
 			name:        "write after 10 seconds still fails",
 			advance:     9 * time.Second,
 			metrics:     &store.PartitionedMetrics{PartitionKey: "a"},
-			expectedErr: ErrWriteLimitReached,
+			expectedErr: ErrWriteLimitReached("a"),
 		},
 		{
 			name:        "write after 10 seconds for another partition succeeds",


### PR DESCRIPTION
This commit ensures that the key being ratelimited is logged along with
the error so admins can diagnose who is causing problems.

cc @brancz @aditya-konarde @s-urbaniak 