### PR TITLE
pkg/oauth2: consider session cancellation

### DIFF
--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -252,11 +252,12 @@ func (o *Options) Run() error {
 				Endpoint: provider.Endpoint(),
 			}
 
-			grantsTotal := prometheus.NewCounter(
+			grantsTotal := prometheus.NewCounterVec(
 				prometheus.CounterOpts{
 					Name: "telemeter_password_credentials_grants_total",
 					Help: "Tracks the number of resource owner password credential grants.",
 				},
+				[]string{"cause", "status"},
 			)
 
 			prometheus.MustRegister(grantsTotal)

--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	oidc "github.com/coreos/go-oidc"
 	"github.com/oklog/run"
 	"github.com/spf13/cobra"
@@ -250,8 +252,17 @@ func (o *Options) Run() error {
 				Endpoint: provider.Endpoint(),
 			}
 
+			grantsTotal := prometheus.NewCounter(
+				prometheus.CounterOpts{
+					Name: "telemeter_password_credentials_grants_total",
+					Help: "Tracks the number of resource owner password credential grants.",
+				},
+			)
+
+			prometheus.MustRegister(grantsTotal)
+
 			src := telemeter_oauth2.NewPasswordCredentialsTokenSource(
-				ctx, &cfg,
+				ctx, &cfg, grantsTotal.Inc,
 				o.AuthorizeUsername, o.AuthorizePassword,
 			)
 

--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -262,7 +262,7 @@ func (o *Options) Run() error {
 			prometheus.MustRegister(grantsTotal)
 
 			src := telemeter_oauth2.NewPasswordCredentialsTokenSource(
-				ctx, &cfg, grantsTotal.Inc,
+				ctx, &cfg, grantsTotal,
 				o.AuthorizeUsername, o.AuthorizePassword,
 			)
 

--- a/pkg/oauth2/token_source.go
+++ b/pkg/oauth2/token_source.go
@@ -7,8 +7,22 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/oauth2"
 )
+
+var (
+	grantsTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "password_credentials_grants_total",
+			Help: "Tracks the number of resource owner password credential grants.",
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(grantsTotal)
+}
 
 type passwordCredentialsTokenSource struct {
 	ctx                context.Context
@@ -81,6 +95,8 @@ func (c *passwordCredentialsTokenSource) Token() (*oauth2.Token, error) {
 }
 
 func (c *passwordCredentialsTokenSource) passwordCredentialsToken() (*oauth2.Token, error) {
+	grantsTotal.Inc()
+
 	tok, err := c.cfg.PasswordCredentialsToken(c.ctx, c.username, c.password)
 	if err != nil {
 		return nil, fmt.Errorf("password credentials token source failed: %v", err)

--- a/pkg/oauth2/token_source.go
+++ b/pkg/oauth2/token_source.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/oauth2"
 )
 
@@ -14,7 +15,7 @@ type passwordCredentialsTokenSource struct {
 	ctx                context.Context
 	cfg                *oauth2.Config
 	username, password string
-	grantsCounter      func()
+	grantsCounter      prometheus.Counter
 
 	mu                sync.Mutex // protects the fields below
 	refreshToken      *oauth2.Token
@@ -34,7 +35,7 @@ type passwordCredentialsTokenSource struct {
 // using the given resource owner and password.
 //
 // It is safe for concurrent use.
-func NewPasswordCredentialsTokenSource(ctx context.Context, cfg *oauth2.Config, grantsCounter func(), username, password string) *passwordCredentialsTokenSource {
+func NewPasswordCredentialsTokenSource(ctx context.Context, cfg *oauth2.Config, grantsCounter prometheus.Counter, username, password string) *passwordCredentialsTokenSource {
 	return &passwordCredentialsTokenSource{
 		ctx:           ctx,
 		username:      username,
@@ -83,7 +84,7 @@ func (c *passwordCredentialsTokenSource) Token() (*oauth2.Token, error) {
 }
 
 func (c *passwordCredentialsTokenSource) passwordCredentialsToken() (*oauth2.Token, error) {
-	c.grantsCounter()
+	c.grantsCounter.Inc()
 
 	tok, err := c.cfg.PasswordCredentialsToken(c.ctx, c.username, c.password)
 	if err != nil {

--- a/pkg/oauth2/token_source_test.go
+++ b/pkg/oauth2/token_source_test.go
@@ -82,7 +82,11 @@ func TestPasswordCredentialsTokenSource(t *testing.T) {
 				},
 			)
 
-			src := NewPasswordCredentialsTokenSource(ctx, conf, prometheus.NewCounter(prometheus.CounterOpts{}), username, password)
+			src := NewPasswordCredentialsTokenSource(
+				ctx, conf, prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"cause", "status"}),
+				username, password,
+			)
+
 			return src, tr
 		}
 	}

--- a/pkg/oauth2/token_source_test.go
+++ b/pkg/oauth2/token_source_test.go
@@ -80,7 +80,8 @@ func TestPasswordCredentialsTokenSource(t *testing.T) {
 				},
 			)
 
-			src := NewPasswordCredentialsTokenSource(ctx, conf, username, password)
+			nop := func() {}
+			src := NewPasswordCredentialsTokenSource(ctx, conf, nop, username, password)
 			return src, tr
 		}
 	}

--- a/pkg/oauth2/token_source_test.go
+++ b/pkg/oauth2/token_source_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"golang.org/x/oauth2"
 )
 
@@ -80,8 +82,7 @@ func TestPasswordCredentialsTokenSource(t *testing.T) {
 				},
 			)
 
-			nop := func() {}
-			src := NewPasswordCredentialsTokenSource(ctx, conf, nop, username, password)
+			src := NewPasswordCredentialsTokenSource(ctx, conf, prometheus.NewCounter(prometheus.CounterOpts{}), username, password)
 			return src, tr
 		}
 	}

--- a/pkg/oauth2/token_source_test.go
+++ b/pkg/oauth2/token_source_test.go
@@ -7,18 +7,47 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
-	"sync/atomic"
 	"testing"
+	"time"
 
 	"golang.org/x/oauth2"
 )
+
+type headerModifier struct {
+	delegate http.RoundTripper
+	header   http.Header
+}
+
+func (hm *headerModifier) RoundTrip(req *http.Request) (*http.Response, error) {
+	r := new(http.Request)
+	*r = *req
+
+	h := make(http.Header, len(req.Header))
+	for k, vs := range req.Header {
+		newvs := make([]string, len(vs))
+		copy(newvs, vs)
+		h[k] = newvs
+	}
+
+	for k, vs := range hm.header {
+		h[k] = vs
+	}
+
+	r.Header = h
+	res, err := hm.delegate.RoundTrip(r)
+	hm.header = make(http.Header)
+	return res, err
+}
+
+func (hm *headerModifier) SetHeader(key, value string) {
+	hm.header.Set(key, value)
+}
 
 func TestPasswordCredentialsTokenSource(t *testing.T) {
 	ts := newTestServer(t)
 	defer ts.Close()
 
 	conf := newConf(ts.URL)
-	src := NewPasswordCredentialsTokenSource(context.Background(), conf, "user1", "password1")
 
 	type checkFunc func(*oauth2.Token, error) error
 
@@ -31,6 +60,68 @@ func TestPasswordCredentialsTokenSource(t *testing.T) {
 			}
 			return nil
 		})
+	}
+
+	type givenFunc func() (oauth2.TokenSource, *headerModifier)
+
+	passwordCredentials := func(username, password string) givenFunc {
+		return func() (oauth2.TokenSource, *headerModifier) {
+			h := make(http.Header)
+
+			tr := &headerModifier{
+				delegate: http.DefaultTransport,
+				header:   h,
+			}
+
+			ctx := context.WithValue(context.Background(), oauth2.HTTPClient,
+				&http.Client{
+					Timeout:   20 * time.Second,
+					Transport: tr,
+				},
+			)
+
+			src := NewPasswordCredentialsTokenSource(ctx, conf, username, password)
+			return src, tr
+		}
+	}
+
+	type whenFunc func(oauth2.TokenSource, *headerModifier) (*oauth2.Token, error)
+
+	steps := func(whens ...whenFunc) whenFunc {
+		return func(src oauth2.TokenSource, m *headerModifier) (tok *oauth2.Token, err error) {
+			for _, wf := range whens {
+				tok, err = wf(src, m)
+				if err != nil {
+					return
+				}
+			}
+			return
+		}
+	}
+
+	expireNextAccessTokenIn := func(expiry int) whenFunc {
+		return func(_ oauth2.TokenSource, m *headerModifier) (*oauth2.Token, error) {
+			m.SetHeader("Expires-In", strconv.Itoa(expiry))
+			return nil, nil
+		}
+	}
+
+	expireNextRefreshTokenIn := func(expiry int) whenFunc {
+		return func(_ oauth2.TokenSource, m *headerModifier) (*oauth2.Token, error) {
+			m.SetHeader("Refresh-Expires-In", strconv.Itoa(expiry))
+			return nil, nil
+		}
+	}
+
+	nextRespondWith := func(code int) whenFunc {
+		return func(_ oauth2.TokenSource, m *headerModifier) (*oauth2.Token, error) {
+			m.SetHeader("Respond-With", strconv.Itoa(code))
+			return nil, nil
+		}
+	}
+
+	getToken := func(src oauth2.TokenSource, m *headerModifier) (*oauth2.Token, error) {
+		return src.Token()
 	}
 
 	hasAccessToken := func(expected string) checkFunc {
@@ -79,26 +170,40 @@ func TestPasswordCredentialsTokenSource(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		init  func(*passwordCredentialsTokenSource)
 		name  string
+		given givenFunc
+		when  whenFunc
 		check checkFunc
 	}{
 		{
 			name: "initial request",
+
+			given: passwordCredentials("user1", "password1"),
+
+			when: getToken,
+
 			check: checks(
 				hasError(nil),
-				hasAccessToken("access_token_1"),
-				hasRefreshToken("refresh_token_1"),
+				hasAccessToken("access_token"),
+				hasRefreshToken("refresh_token"),
 				hasTokenType("bearer"),
 				isValid(true),
 			),
 		},
 		{
 			name: "reuse access token",
+
+			given: passwordCredentials("user1", "password1"),
+
+			when: steps(
+				getToken,
+				getToken,
+			),
+
 			check: checks(
 				hasError(nil),
-				hasAccessToken("access_token_1"),
-				hasRefreshToken("refresh_token_1"),
+				hasAccessToken("access_token"),
+				hasRefreshToken("refresh_token"),
 				hasTokenType("bearer"),
 				isValid(true),
 			),
@@ -106,23 +211,50 @@ func TestPasswordCredentialsTokenSource(t *testing.T) {
 		{
 			name: "refresh the refresh token",
 
-			// invalidate current refresh token
-			init: func(src *passwordCredentialsTokenSource) { src.refreshToken = nil },
+			given: passwordCredentials("user1", "password1"),
+
+			when: steps(
+				// let the first token to be expired immediately
+				expireNextRefreshTokenIn(-1),
+				getToken,
+				// let the second refresh token be not expired
+				expireNextRefreshTokenIn(100),
+				getToken,
+			),
 
 			check: checks(
 				hasError(nil),
-				hasAccessToken("access_token_2"),
-				hasRefreshToken("refresh_token_2"),
+				hasAccessToken("access_token"),
+				hasRefreshToken("refresh_token"),
+				hasTokenType("bearer"),
+				isValid(true),
+			),
+		},
+		{
+			name: "invalidate refresh token session",
+
+			given: passwordCredentials("user1", "password1"),
+
+			when: steps(
+				// let the first access token be expired immmediately
+				expireNextAccessTokenIn(-1),
+				expireNextRefreshTokenIn(100),
+				getToken,
+				nextRespondWith(http.StatusBadRequest),
+				getToken,
+			),
+
+			check: checks(
+				hasError(nil),
+				hasAccessToken("access_token"),
+				hasRefreshToken("refresh_token"),
 				hasTokenType("bearer"),
 				isValid(true),
 			),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.init != nil {
-				tc.init(src)
-			}
-			if err := tc.check(src.Token()); err != nil {
+			if err := tc.check(tc.when(tc.given())); err != nil {
 				t.Error(err)
 			}
 		})
@@ -142,41 +274,61 @@ func newConf(url string) *oauth2.Config {
 }
 
 func newTestServer(t *testing.T) *httptest.Server {
-	var counter uint64
-
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
+
 		expected := "/token"
 		if r.URL.String() != expected {
-			t.Errorf("URL = %q; want %q", r.URL, expected)
+			t.Fatalf("URL = %q; want %q", r.URL, expected)
 		}
 		headerAuth := r.Header.Get("Authorization")
+		// CLIENT_ID:CLIENT_SECRET
 		expected = "Basic Q0xJRU5UX0lEOkNMSUVOVF9TRUNSRVQ="
 		if headerAuth != expected {
-			t.Errorf("Authorization header = %q; want %q", headerAuth, expected)
+			t.Fatalf("Authorization header = %q; want %q", headerAuth, expected)
 		}
+
+		if codestr, ok := r.Header["Respond-With"]; ok {
+			code, err := strconv.Atoi(codestr[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			w.WriteHeader(code)
+			return
+		}
+
 		headerContentType := r.Header.Get("Content-Type")
 		expected = "application/x-www-form-urlencoded"
 		if headerContentType != expected {
-			t.Errorf("Content-Type header = %q; want %q", headerContentType, expected)
+			t.Fatalf("Content-Type header = %q; want %q", headerContentType, expected)
 		}
+
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			t.Errorf("Failed reading request body: %s.", err)
+			t.Fatalf("Failed reading request body: %s.", err)
 		}
+
 		expected = "grant_type=password&password=password1&username=user1"
 		if string(body) != expected {
 			t.Errorf("res.Body = %q; want %q", string(body), expected)
 		}
 		w.Header().Set("Content-Type", "application/json")
 
-		cnt := int(atomic.AddUint64(&counter, 1))
+		refreshExpiresIn := "100"
+		if _, ok := r.Header["Refresh-Expires-In"]; ok {
+			refreshExpiresIn = r.Header.Get("Refresh-Expires-In")
+		}
+
+		expiresIn := "100"
+		if _, ok := r.Header["Expires-In"]; ok {
+			expiresIn = r.Header.Get("Expires-In")
+		}
 
 		if _, err := w.Write([]byte(`{
-  "access_token": "access_token_` + strconv.Itoa(cnt) + `",
-  "expires_in": ` + strconv.Itoa(cnt) + `00,
-  "refresh_expires_in": ` + strconv.Itoa(cnt) + `00,
-  "refresh_token": "refresh_token_` + strconv.Itoa(cnt) + `",
+  "access_token": "access_token",
+  "expires_in": ` + expiresIn + `,
+  "refresh_expires_in": ` + refreshExpiresIn + `,
+  "refresh_token": "refresh_token",
   "token_type": "bearer"
 }`)); err != nil {
 			t.Errorf("error writing token: %v", err)


### PR DESCRIPTION
Currently, if telemeter assumes a refresh token is still valid, it will
treat errors from fetching an access token as fatal.

In reality, the authorization server might have reset our session and
invalidate the refresh token server-side despite still being valid.

In that case it returns a 400 status code.

This fixes it.

Fixes MON-690

/cc @brancz @squat @paulfantom