### PR TITLE
jsonnet: Bump prometheus-operator

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter"
                 }
             },
-            "version": "e580d1f71da91e809c0f52dc6272536cf08605a9"
+            "version": "395b0a2dcd605c92dc9f0414ad2fde003f5a558b"
         },
         {
             "name": "ksonnet",
@@ -18,7 +18,7 @@
                     "subdir": ""
                 }
             },
-            "version": "d03da231d6c8bd74437b74a1e9e8b966f13dffa2"
+            "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f"
         },
         {
             "name": "prometheus-operator",
@@ -28,7 +28,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "bd5feacc528f0bcb69fb9167dacb2700eb75d322"
+            "version": "18fbf558ab7f8809fd610a3dc50bf483508dc1bb"
         }
     ]
 }

--- a/jsonnet/telemeter/jsonnetfile.json
+++ b/jsonnet/telemeter/jsonnetfile.json
@@ -18,7 +18,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "v0.30.0"
+            "version": "release-0.30"
         }
     ]
 }

--- a/manifests/benchmark/clusterRoleBindingPrometheusOperator.yaml
+++ b/manifests/benchmark/clusterRoleBindingPrometheusOperator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     apps.kubernetes.io/component: controller
     apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.29.0
+    apps.kubernetes.io/version: v0.30.0
   name: prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/benchmark/deploymentPrometheusOperator.yaml
+++ b/manifests/benchmark/deploymentPrometheusOperator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     apps.kubernetes.io/component: controller
     apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.29.0
+    apps.kubernetes.io/version: v0.30.0
   name: prometheus-operator
   namespace: telemeter-benchmark
 spec:
@@ -18,15 +18,15 @@ spec:
       labels:
         apps.kubernetes.io/component: controller
         apps.kubernetes.io/name: prometheus-operator
-        apps.kubernetes.io/version: v0.29.0
+        apps.kubernetes.io/version: v0.30.0
     spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
         - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.29.0
-        image: quay.io/coreos/prometheus-operator:v0.29.0
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.30.0
+        image: quay.io/coreos/prometheus-operator:v0.30.0
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/manifests/benchmark/serviceAccountPrometheusOperator.yaml
+++ b/manifests/benchmark/serviceAccountPrometheusOperator.yaml
@@ -4,6 +4,6 @@ metadata:
   labels:
     apps.kubernetes.io/component: controller
     apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.29.0
+    apps.kubernetes.io/version: v0.30.0
   name: prometheus-operator
   namespace: telemeter-benchmark


### PR DESCRIPTION
This is required to resolve the version conflict of bumping kube-prometheus in the cluster-monitoring-operator.

@s-urbaniak @squat @paulfantom @metalmatze 