### PR TITLE
Makefile: unblock golangci-lint installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ PKGS=$(shell go list ./... | grep -v -E '/vendor/|/test')
 GOLANG_FILES:=$(shell find . -name \*.go -print)
 FIRST_GOPATH:=$(firstword $(subst :, ,$(shell go env GOPATH)))
 GOLANGCI_LINT_BIN=$(FIRST_GOPATH)/bin/golangci-lint
+GOLANGCI_LINT_VERSION=v1.16.0
 EMBEDMD_BIN=$(FIRST_GOPATH)/bin/embedmd
 GOJSONTOYAML_BIN=$(FIRST_GOPATH)/bin/gojsontoyaml
 # We need jsonnet on CI; here we default to the user's installed jsonnet binary; if nothing is installed, then install go-jsonnet.
@@ -183,4 +184,6 @@ $(GOJSONTOYAML_BIN):
 	GO111MODULE=off go get -u github.com/brancz/gojsontoyaml
 
 $(GOLANGCI_LINT_BIN):
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(FIRST_GOPATH)/bin v1.16.0
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh \
+		| sed -e '/install -d/d' \
+		| sh -s -- -b $(FIRST_GOPATH)/bin $(GOLANGCI_LINT_VERSION)


### PR DESCRIPTION
This is to unblock things until https://github.com/golangci/golangci-lint/issues/575 gets fixed. This is similar to what's been done in https://github.com/prometheus/prometheus/pull/5658.

cc @paulfantom 