### PR TITLE
Bump prometheus operator

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter"
                 }
             },
-            "version": "395b0a2dcd605c92dc9f0414ad2fde003f5a558b"
+            "version": "b6515f17cae04b90c7c3b29e459e2752f1d8bc6a"
         },
         {
             "name": "ksonnet",
@@ -28,7 +28,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "18fbf558ab7f8809fd610a3dc50bf483508dc1bb"
+            "version": "f05d5228fe02bcd370acaa234c15f3d9fdef4a60"
         }
     ]
 }

--- a/jsonnet/telemeter/jsonnetfile.json
+++ b/jsonnet/telemeter/jsonnetfile.json
@@ -18,7 +18,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "release-0.30"
+            "version": "release-0.31"
         }
     ]
 }

--- a/manifests/benchmark/clusterRoleBindingPrometheusOperator.yaml
+++ b/manifests/benchmark/clusterRoleBindingPrometheusOperator.yaml
@@ -2,9 +2,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.30.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.31.0
   name: prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/benchmark/deploymentPrometheusOperator.yaml
+++ b/manifests/benchmark/deploymentPrometheusOperator.yaml
@@ -1,32 +1,32 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.30.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.31.0
   name: prometheus-operator
   namespace: telemeter-benchmark
 spec:
   replicas: 1
   selector:
     matchLabels:
-      apps.kubernetes.io/component: controller
-      apps.kubernetes.io/name: prometheus-operator
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/name: prometheus-operator
   template:
     metadata:
       labels:
-        apps.kubernetes.io/component: controller
-        apps.kubernetes.io/name: prometheus-operator
-        apps.kubernetes.io/version: v0.30.0
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/name: prometheus-operator
+        app.kubernetes.io/version: v0.31.0
     spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
         - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.30.0
-        image: quay.io/coreos/prometheus-operator:v0.30.0
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.31.0
+        image: quay.io/coreos/prometheus-operator:v0.31.0
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/manifests/benchmark/serviceAccountPrometheusOperator.yaml
+++ b/manifests/benchmark/serviceAccountPrometheusOperator.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.30.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.31.0
   name: prometheus-operator
   namespace: telemeter-benchmark


### PR DESCRIPTION
This is necessary to bump cluster-monitoring-operator's kube-prometheus (update on kube-prometheus still pending).

@s-urbaniak @paulfantom @squat @metalmatze 