### PR TITLE
test/benchmark: cut down flakes and speed up test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ test-integration: build
 	./test/integration.sh
 
 test-benchmark: build
-	./test/benchmark.sh "" "" "" "" $(BENCHMARK_GOAL)
+	./test/benchmark.sh "" "" $(BENCHMARK_GOAL) "" $(BENCHMARK_GOAL)
 
 test/timeseries.txt:
 	oc port-forward -n openshift-monitoring prometheus-k8s-0 9090 > /dev/null & \

--- a/test/benchmark.sh
+++ b/test/benchmark.sh
@@ -47,7 +47,7 @@ create() {
     # Create everything but the Prometheus resource.
     find ./manifests/benchmark/ ! -name 'prometheus*' -type f -print0 | xargs -0l -I{} oc apply -f {} > /dev/null
     oc scale statefulset telemeter-server --namespace telemeter-benchmark --replicas "$SERVERS"
-    local retries=10
+    local retries=20
     until [ "$(oc get pods -n telemeter-benchmark | grep telemeter-server- | grep Running -c)" -eq "$SERVERS" ]; do
         retries=$((retries-1))
         if [ $retries -eq 0 ]; then
@@ -61,7 +61,7 @@ create() {
     # Create everything but the Telemeter server resources as we want
     # to avoid undoing the scaling event.
     find ./manifests/benchmark/ ! -name '*TelemeterServer.yaml' -type f -print0 | xargs -0l -I{} oc apply -f {} > /dev/null
-    local retries=10
+    local retries=20
     until [ "$(oc get pods -n telemeter-benchmark | grep prometheus-benchmark | grep Running -c)" -eq 1 ]; do
         retries=$((retries-1))
         if [ $retries -eq 0 ]; then

--- a/test/benchmark.sh
+++ b/test/benchmark.sh
@@ -14,8 +14,9 @@ trap 'rc=$?; printf "cleaning up...\n" && oc delete -f ./manifests/benchmark/ --
 
 benchmark() {
     local current=$1
+    local goal=$2
     local success=0
-    while [ "$GOAL" == 0 ] || [ "$success" -lt "$GOAL" ]; do
+    while [ "$goal" == 0 ] || [ "$success" -lt "$goal" ]; do
         printf "benchmarking with %d clients sending %d time series\n" "$current" "$TSN"
         create
         client "$current" http://"$(route telemeter-server)" &
@@ -28,7 +29,7 @@ benchmark() {
     done
     printf "Successfully handled %s clients\n" "$success"
     # Only return non-zero if we set a goal and didn't meet it.
-    if [ "$GOAL" -gt 0 ] && [ "$success" -lt "$GOAL" ]; then
+    if [ "$goal" -gt 0 ] && [ "$success" -lt "$goal" ]; then
         return 1
     fi
     return 0
@@ -120,6 +121,6 @@ save() {
     echo "$res" > "$DIR"/"$SERVERS"_"$n"_mem.json
 }
 
-benchmark "$CLIENTS"
+benchmark "$CLIENTS" "$GOAL"
 
 exit $?


### PR DESCRIPTION
This PR cuts down flakes with:
* This commit doubles the amount of time that the benchmark suite will
wait for the Prometheus server to be ready on the cluster up to 200s.
Benchmark tests are flaking because occasionally Prometheus takes too
long to come up. If necessary, we can bump this further.

This PR speeds up the test by:
* This commit ensures that the benchmark test will begin and end with the
goal value. Formerly, the benchmark test would begin at 1000 and end at
the goal, allowing the runner to find the highest successful value;
however, this takes a very long time. Now, the test will start at 5000
and exit 0 or 1 depending on if the test succeeds.

cc @paulfantom @s-urbaniak 