### PR TITLE
Add Route annotation to ServiceAccount for thanos-querier

### DIFF
--- a/jsonnet/telemeter/prometheus/kubernetes.libsonnet
+++ b/jsonnet/telemeter/prometheus/kubernetes.libsonnet
@@ -41,6 +41,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       serviceAccount.new('prometheus-' + $._config.prometheus.name) +
       serviceAccount.mixin.metadata.withNamespace($._config.namespace) +
       serviceAccount.mixin.metadata.withAnnotations({
+        // TODO: Remove observatorium-thanos-querier once we have a separate clusterRole
         'serviceaccounts.openshift.io/oauth-redirectreference.observatorium-thanos-querier':'{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"observatorium-thanos-querier"}}',
         'serviceaccounts.openshift.io/oauth-redirectreference.prometheus-k8s': '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"prometheus-telemeter"}}',
       }),

--- a/jsonnet/telemeter/prometheus/kubernetes.libsonnet
+++ b/jsonnet/telemeter/prometheus/kubernetes.libsonnet
@@ -41,6 +41,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       serviceAccount.new('prometheus-' + $._config.prometheus.name) +
       serviceAccount.mixin.metadata.withNamespace($._config.namespace) +
       serviceAccount.mixin.metadata.withAnnotations({
+        'serviceaccounts.openshift.io/oauth-redirectreference.observatorium-thanos-querier':'{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"observatorium-thanos-querier"}}',
         'serviceaccounts.openshift.io/oauth-redirectreference.prometheus-k8s': '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"prometheus-telemeter"}}',
       }),
 

--- a/manifests/prometheus/list.yaml
+++ b/manifests/prometheus/list.yaml
@@ -217,6 +217,7 @@ objects:
   kind: ServiceAccount
   metadata:
     annotations:
+      serviceaccounts.openshift.io/oauth-redirectreference.observatorium-thanos-querier: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"observatorium-thanos-querier"}}'
       serviceaccounts.openshift.io/oauth-redirectreference.prometheus-k8s: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"prometheus-telemeter"}}'
     name: prometheus-telemeter
     namespace: ${NAMESPACE}

--- a/manifests/prometheus/serviceAccount.yaml
+++ b/manifests/prometheus/serviceAccount.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.observatorium-thanos-querier: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"observatorium-thanos-querier"}}'
     serviceaccounts.openshift.io/oauth-redirectreference.prometheus-k8s: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"prometheus-telemeter"}}'
   name: prometheus-telemeter
   namespace: telemeter


### PR DESCRIPTION
We need to update the annotations on the prometheus-telemeter to use its ServiceAccount for the Thanos querier too.

/cc @aditya-konarde @brancz @squat 