### PR TITLE
 jsonnet: change benchmark crb name

### DIFF
--- a/jsonnet/telemeter/benchmark.libsonnet
+++ b/jsonnet/telemeter/benchmark.libsonnet
@@ -13,7 +13,7 @@ local b = (import 'prometheus-operator/prometheus-operator.libsonnet') +
 
 {
   prometheusOperator+:: {
-    clusterRoleBinding: b.prometheusOperator.clusterRoleBinding,
+    clusterRoleBinding: b.prometheusOperator.clusterRoleBinding { metadata+: { name: 'telemeter-benchmark' } },
     serviceAccount: b.prometheusOperator.serviceAccount,
     deployment: b.prometheusOperator.deployment {
       spec+: {

--- a/manifests/benchmark/clusterRoleBindingPrometheusOperator.yaml
+++ b/manifests/benchmark/clusterRoleBindingPrometheusOperator.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/version: v0.31.0
-  name: prometheus-operator
+  name: telemeter-benchmark
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
This commit changes the name of the benchmarking Prometheus Operator
cluster role binding. Today, this cluster role binding has the same name
as the cluster role binding for Prometheus Operator created by the
monitoring stack but a different subject.

The result is that on a regular OpenShift cluster, the
benchmarking CRB will be overwritten by the CMO. When the CRB is
overwritten, the benchmarking Prometheus-Operator no longer has the
correct privileges and crashloops. This causes flakiness in the
benchmarking tests: when the timing is right, the benchmarking
Prometheus Operator is able to create a Prometheus, and when the timing
is wrong, it is not able to create a Prometheus, causing the tests to
fail.

cc @paulfantom @metalmatze @aditya-konarde @s-urbaniak 