### PR TITLE
Increase token store authorizer timeout to 30s

### DIFF
--- a/pkg/authorize/token_store.go
+++ b/pkg/authorize/token_store.go
@@ -34,7 +34,7 @@ func (t *tokenStore) Load(endpoint *url.URL, initialToken string, rt http.RoundT
 		return t.value, nil
 	}
 
-	c := http.Client{Transport: rt, Timeout: 10 * time.Second}
+	c := http.Client{Transport: rt, Timeout: 30 * time.Second}
 	req, err := http.NewRequest("POST", endpoint.String(), nil)
 	if err != nil {
 		return "", fmt.Errorf("unable to create authentication request: %v", err)


### PR DESCRIPTION
Increase the token store authorizer timeout to avoid repeating requests during times of high load.

This should be a temporary change, we do not expect requests to take longer than 10s in the long term. We are making changes on the UHC/OCM end to achieve this after a recent service degradation:

1. Larger RDS instance size, database is currently a bottleneck: https://jira.coreos.com/browse/APPSRE-820
2. Profile database, collect performance information, and optimize DB queries: https://jira.coreos.com/browse/SDB-574
3. Setting sane http and DB connection limits: https://jira.coreos.com/browse/SDB-575

Postmortem is still on-going and further improvements may be necessary.