### PR TITLE
Log the mean drift from current timestamp when forward fails

### DIFF
--- a/pkg/store/forward/forward.go
+++ b/pkg/store/forward/forward.go
@@ -108,13 +108,16 @@ func (s *Store) WriteMetrics(ctx context.Context, p *store.PartitionedMetrics) e
 				WithLabelValues(fmt.Sprintf("%d", resp.StatusCode)).
 				Observe(time.Since(begin).Seconds())
 
-			if resp.StatusCode/100 != 2 {
-				meanDrift := timeseriesMeanDrift(timeseries, time.Now().Unix())
-				return fmt.Errorf("response status code is %s - mean drift from now for clusters %s is: %.3fs",
-					resp.Status,
+			meanDrift := timeseriesMeanDrift(timeseries, time.Now().Unix())
+			if meanDrift > 10 {
+				log.Printf("mean drift from now for clusters %s is: %.3fs",
 					p.PartitionKey,
 					meanDrift,
 				)
+			}
+
+			if resp.StatusCode/100 != 2 {
+				return fmt.Errorf("response status code is %s", resp.Status)
 			}
 
 			s := 0

--- a/pkg/store/forward/forward.go
+++ b/pkg/store/forward/forward.go
@@ -110,8 +110,9 @@ func (s *Store) WriteMetrics(ctx context.Context, p *store.PartitionedMetrics) e
 
 			if resp.StatusCode/100 != 2 {
 				mean := timeseriesMeanDrift(timeseries, time.Now().Unix()*1000)
-				return fmt.Errorf("response status code is %s - timestamp mean from now is: %.3fms",
+				return fmt.Errorf("response status code is %s - mean drift from now for clusters %S is: %.3fms",
 					resp.Status,
+					p.PartitionKey,
 					float64(time.Now().Second())-mean,
 				)
 			}

--- a/pkg/store/forward/forward.go
+++ b/pkg/store/forward/forward.go
@@ -109,8 +109,8 @@ func (s *Store) WriteMetrics(ctx context.Context, p *store.PartitionedMetrics) e
 				Observe(time.Since(begin).Seconds())
 
 			if resp.StatusCode/100 != 2 {
-				mean := timeseriesMeanDrift(timeseries, time.Now().Unix()*1000)
-				return fmt.Errorf("response status code is %s - mean drift from now for clusters %S is: %.3fms",
+				mean := timeseriesMeanDrift(timeseries, time.Now().Unix())
+				return fmt.Errorf("response status code is %s - mean drift from now for clusters %s is: %.3fs",
 					resp.Status,
 					p.PartitionKey,
 					float64(time.Now().Second())-mean,

--- a/pkg/store/forward/forward.go
+++ b/pkg/store/forward/forward.go
@@ -109,11 +109,11 @@ func (s *Store) WriteMetrics(ctx context.Context, p *store.PartitionedMetrics) e
 				Observe(time.Since(begin).Seconds())
 
 			if resp.StatusCode/100 != 2 {
-				mean := timeseriesMeanDrift(timeseries, time.Now().Unix())
+				meanDrift := timeseriesMeanDrift(timeseries, time.Now().Unix())
 				return fmt.Errorf("response status code is %s - mean drift from now for clusters %s is: %.3fs",
 					resp.Status,
 					p.PartitionKey,
-					float64(time.Now().Second())-mean,
+					meanDrift,
 				)
 			}
 

--- a/pkg/store/forward/forward_test.go
+++ b/pkg/store/forward/forward_test.go
@@ -189,3 +189,26 @@ func timeseriesEqual(t1 []prompb.TimeSeries, t2 []prompb.TimeSeries) (bool, erro
 
 	return true, nil
 }
+
+func Test_timeseriesMean(t *testing.T) {
+	ts := []prompb.TimeSeries{{
+		Samples: []prompb.Sample{
+			{Value: 0, Timestamp: 15615582010000},
+			{Value: 0, Timestamp: 15615582020000},
+			{Value: 0, Timestamp: 15615582030000},
+			{Value: 0, Timestamp: 15615582040000},
+			{Value: 0, Timestamp: 15615582050000},
+		},
+	}, {
+		Samples: []prompb.Sample{
+			{Value: 0, Timestamp: 15615582000000},
+			{Value: 0, Timestamp: 15615582010000},
+			{Value: 0, Timestamp: 15615582020000},
+		},
+	}}
+
+	mean := timeseriesMeanDrift(ts, 15615582050)
+	if mean != 27.50 {
+		t.Errorf("expected mean to be 2.75, but got: %.3f", mean)
+	}
+}


### PR DESCRIPTION
For every failed request we will get the mean drift from the current timestamp. This should be helpful to find clusters that are way off.

/cc @squat @kakkoyun @brancz 