### PR TITLE
Makefile: bump benchmark goal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ JSONNET_BIN=$(if $(shell which jsonnet 2>/dev/null),$(shell which jsonnet 2>/dev
 JB_BIN=$(FIRST_GOPATH)/bin/jb
 JSONNET_SRC=$(shell find ./jsonnet -type f)
 BENCHMARK_RESULTS=$(shell find ./benchmark -type f -name '*.json')
-BENCHMARK_GOAL?=5000
+BENCHMARK_GOAL?=9000
 JSONNET_VENDOR=jsonnet/jsonnetfile.lock.json jsonnet/vendor
 DOCS=$(shell grep -rlF [embedmd] docs)
 


### PR DESCRIPTION
ran a new round of benchmarks and found we can currently handle 9000 clusters

cc @metalmatze @kakkoyun 