### PR TITLE
Log mean drift time for cluster more than 10s apart

### DIFF
--- a/pkg/store/forward/forward.go
+++ b/pkg/store/forward/forward.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"net/http"
 	"net/url"
 	"time"
@@ -109,7 +110,7 @@ func (s *Store) WriteMetrics(ctx context.Context, p *store.PartitionedMetrics) e
 				Observe(time.Since(begin).Seconds())
 
 			meanDrift := timeseriesMeanDrift(timeseries, time.Now().Unix())
-			if meanDrift > 10 {
+			if math.Abs(meanDrift) > 10 {
 				log.Printf("mean drift from now for clusters %s is: %.3fs",
 					p.PartitionKey,
 					meanDrift,


### PR DESCRIPTION
We want to also log clusters that ingest data being in the future with a mean more than 10s.

/cc @squat