### PR TITLE
 pkg/store/forward: only overwrite future timestamps

### DIFF
--- a/pkg/store/forward/forward.go
+++ b/pkg/store/forward/forward.go
@@ -40,6 +40,7 @@ var (
 )
 
 func init() {
+	prometheus.MustRegister(forwardSamples)
 	prometheus.MustRegister(forwardErrors)
 	prometheus.MustRegister(forwardDuration)
 }


### PR DESCRIPTION
Only overwrite timestamps that are in the future.
Also expose a metric to track how many timestamps are being overwritten.

cc @brancz @metalmatze 