### PR TITLE
pkg/store/forward: add tenant header

### DIFF
--- a/pkg/store/forward/forward.go
+++ b/pkg/store/forward/forward.go
@@ -95,6 +95,7 @@ func (s *Store) WriteMetrics(ctx context.Context, p *store.PartitionedMetrics) e
 			if err != nil {
 				return err
 			}
+			req.Header.Add("THANOS-TENANT", p.PartitionKey)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()


### PR DESCRIPTION
This commit adds the Thanos tenant header to all requests forwarded to
the receive components. This will keep us prepared for when every tenant
has its own TSDB and will also help us track failures in the receive
component per tenant.

cc @brancz @metalmatze @kakkoyun 