### PR TITLE
Bug 1732945:  jsonnet/telemeter/jsonnetfile.json: Adjust syncs

### DIFF
--- a/jsonnet/telemeter/jsonnetfile.json
+++ b/jsonnet/telemeter/jsonnetfile.json
@@ -18,7 +18,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "v0.30.0"
+            "version": "release-0.30"
         }
     ]
 }


### PR DESCRIPTION
kube-prom pins this version to release-0.30 release. Currently this is
causing conflicts when running jb update in CMO.

https://github.com/coreos/kube-prometheus/blob/release-0.1/jsonnet/kube-prometheus/jsonnetfile.json#L41

cc @brancz 