### PR TITLE
Add a receive handler to Telemeter for remote-write

### DIFF
--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -116,6 +116,7 @@ func main() {
 	cmd.Flags().StringVar(&opt.OIDCIssuer, "oidc-issuer", opt.OIDCIssuer, "The OIDC issuer URL, see https://openid.net/specs/openid-connect-discovery-1_0.html#IssuerDiscovery.")
 	cmd.Flags().StringVar(&opt.ClientSecret, "client-secret", opt.ClientSecret, "The OIDC client secret, see https://tools.ietf.org/html/rfc6749#section-2.3.")
 	cmd.Flags().StringVar(&opt.ClientID, "client-id", opt.ClientID, "The OIDC client ID, see https://tools.ietf.org/html/rfc6749#section-2.3.")
+	cmd.Flags().StringVar(&opt.TenantKey, "tenant-key", opt.TenantKey, "The JSON key in the bearer token whose value to use as the tenant ID.")
 
 	cmd.Flags().DurationVar(&opt.Ratelimit, "ratelimit", opt.Ratelimit, "The rate limit of metric uploads per cluster ID. Uploads happening more often than this limit will be rejected.")
 	cmd.Flags().DurationVar(&opt.TTL, "ttl", opt.TTL, "The TTL for metrics to be held in memory.")
@@ -155,6 +156,7 @@ type Options struct {
 	OIDCIssuer   string
 	ClientID     string
 	ClientSecret string
+	TenantKey    string
 
 	PartitionKey      string
 	LabelFlag         []string
@@ -356,9 +358,7 @@ func (o *Options) Run() error {
 	secret := h.Sum(nil)[:32]
 
 	external := http.NewServeMux()
-	externalProtected := http.NewServeMux()
 	internal := http.NewServeMux()
-	internalProtected := http.NewServeMux()
 
 	internalPaths := []string{"/", "/federate", "/metrics", "/debug/pprof", "/healthz", "/healthz/ready"}
 
@@ -411,7 +411,7 @@ func (o *Options) Run() error {
 			}()
 		}
 		internalPaths = append(internalPaths, "/debug/cluster")
-		internalProtected.Handle("/debug/cluster", c)
+		internal.Handle("/debug/cluster", c)
 		store = c
 		// Wrap the cluster store within a rate-limited store.
 		// This guarantees an upper-bound on the total inter-node requests that
@@ -439,8 +439,7 @@ func (o *Options) Run() error {
 	externalPathJSON, _ := json.MarshalIndent(Paths{Paths: []string{"/", "/authorize", "/upload", "/healthz", "/healthz/ready", "/metrics/v1/receive"}}, "", "  ")
 
 	// TODO: add internal authorization
-	telemeter_http.DebugRoutes(internalProtected)
-	internalProtected.Handle("/federate", http.HandlerFunc(server.Get))
+	telemeter_http.DebugRoutes(internal)
 
 	internal.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.URL.Path == "/" && req.Method == "GET" {
@@ -450,13 +449,11 @@ func (o *Options) Run() error {
 			}
 			return
 		}
-		internalProtected.ServeHTTP(w, req)
+		w.WriteHeader(http.StatusNotFound)
 	}))
+	internal.Handle("/federate", http.HandlerFunc(server.Get))
 	telemeter_http.MetricRoutes(internal)
 	telemeter_http.HealthRoutes(internal)
-
-	externalProtected.Handle("/upload", telemeter_http.NewInstrumentedHandler("upload", http.HandlerFunc(server.Post)))
-	externalProtectedHandler := authorize.NewAuthorizeClientHandler(jwtAuthorizer, externalProtected)
 
 	external.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.URL.Path == "/" && req.Method == "GET" {
@@ -466,13 +463,24 @@ func (o *Options) Run() error {
 			}
 			return
 		}
-		externalProtectedHandler.ServeHTTP(w, req)
+		w.WriteHeader(http.StatusNotFound)
 	}))
 	telemeter_http.HealthRoutes(external)
+
+	// v1 routes
 	external.Handle("/authorize", telemeter_http.NewInstrumentedHandler("authorize", auth))
+	external.Handle("/upload",
+		authorize.NewAuthorizeClientHandler(jwtAuthorizer,
+			telemeter_http.NewInstrumentedHandler("upload",
+				http.HandlerFunc(server.Post),
+			),
+		),
+	)
+
+	// v1 routes
 	external.Handle("/metris/v1/receive",
 		telemeter_http.NewInstrumentedHandler("receive",
-			receiver.Authorizer(clusterAuth,
+			authorize.NewHandler(authorizeClient, authorizeURL, o.TenantKey,
 				http.HandlerFunc(receiver.Receive),
 			),
 		),

--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -472,9 +472,9 @@ func (o *Options) Run() error {
 	external.Handle("/authorize", telemeter_http.NewInstrumentedHandler("authorize", auth))
 	external.Handle("/metris/v1/receive",
 		telemeter_http.NewInstrumentedHandler("receive",
-			//receiver.Authorizer(clusterAuth,
-			http.HandlerFunc(receiver.Receive),
-			//),
+			receiver.Authorizer(clusterAuth,
+				http.HandlerFunc(receiver.Receive),
+			),
 		),
 	)
 

--- a/pkg/authorize/client.go
+++ b/pkg/authorize/client.go
@@ -13,10 +13,6 @@ type Client struct {
 	Labels map[string]string
 }
 
-var clientKey key
-
-type key int
-
 func WithClient(ctx context.Context, client *Client) context.Context {
 	return context.WithValue(ctx, clientKey, client)
 }

--- a/pkg/authorize/context.go
+++ b/pkg/authorize/context.go
@@ -1,0 +1,8 @@
+package authorize
+
+type key int
+
+const (
+	clientKey key = iota
+	TenantKey
+)

--- a/pkg/authorize/handler.go
+++ b/pkg/authorize/handler.go
@@ -56,6 +56,8 @@ func (e errorWithCode) HTTPStatusCode() int {
 	return e.code
 }
 
+const requestBodyLimit = 32 * 1024 // 32MiB
+
 func AgainstEndpoint(client *http.Client, endpoint *url.URL, buf io.Reader, cluster string, validate func(*http.Response) error) ([]byte, error) {
 	req, err := http.NewRequest("POST", endpoint.String(), buf)
 	if err != nil {
@@ -80,7 +82,8 @@ func AgainstEndpoint(client *http.Client, endpoint *url.URL, buf io.Reader, clus
 			res.Body.Close()
 		}
 	}()
-	body, err := ioutil.ReadAll(io.LimitReader(res.Body, 32*1024))
+
+	body, err := ioutil.ReadAll(io.LimitReader(res.Body, requestBodyLimit))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authorize/jwt/handler.go
+++ b/pkg/authorize/jwt/handler.go
@@ -71,12 +71,7 @@ func (a *authorizeClusterHandler) ServeHTTP(w http.ResponseWriter, req *http.Req
 	subject, err := a.clusterAuth.AuthorizeCluster(clientToken, cluster)
 
 	if err != nil {
-		type statusCodeErr interface {
-			Error() string
-			HTTPStatusCode() int
-		}
-
-		if scerr, ok := err.(statusCodeErr); ok {
+		if scerr, ok := err.(authorize.ErrorWithCode); ok {
 			if scerr.HTTPStatusCode() >= http.StatusInternalServerError {
 				log.Printf("error: unable to authorize request: %v", scerr)
 			}

--- a/pkg/authorize/tollbooth/tollbooth.go
+++ b/pkg/authorize/tollbooth/tollbooth.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"log"
 	"mime"
 	"net/http"
 	"net/url"
+
+	"github.com/openshift/telemeter/pkg/authorize"
 )
 
 type clusterRegistration struct {
@@ -46,83 +46,29 @@ func (a *authorizer) AuthorizeCluster(token, cluster string) (string, error) {
 		return "", err
 	}
 
-	req, err := http.NewRequest("POST", a.to.String(), bytes.NewReader(data))
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-	resp, err := a.client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer func() {
-		// read the body to keep the upstream connection open
-		if resp.Body != nil {
-			if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
-				log.Printf("error copying body: %v", err)
-			}
-			resp.Body.Close()
+	body, err := authorize.AgainstEndpoint(a.client, a.to, bytes.NewReader(data), cluster, func(res *http.Response) error {
+		contentType := res.Header.Get("Content-Type")
+		mediaType, _, err := mime.ParseMediaType(contentType)
+		if err != nil || mediaType != "application/json" {
+			log.Printf("warning: Upstream server %s responded with an unknown content type %q", a.to, contentType)
+			return fmt.Errorf("unrecognized token response content-type %q", contentType)
 		}
-	}()
-	switch resp.StatusCode {
-	case http.StatusUnauthorized:
-		return "", errWithCode{error: fmt.Errorf("unauthorized"), code: http.StatusUnauthorized}
-	case http.StatusTooManyRequests:
-		return "", errWithCode{error: fmt.Errorf("rate limited, please try again later"), code: http.StatusTooManyRequests}
-	case http.StatusConflict:
-		return "", errWithCode{error: fmt.Errorf("the provided cluster identifier is already in use under a different account or is not sufficiently random"), code: http.StatusConflict}
-	case http.StatusNotFound:
-		return "", errWithCode{error: fmt.Errorf("not found"), code: http.StatusNotFound}
-	case http.StatusOK, http.StatusCreated:
-		// allowed
-	default:
-		tryLogBody(resp.Body, 4*1024, fmt.Sprintf("warning: Upstream server rejected request for cluster %q with body:\n%%s", cluster))
-		return "", errWithCode{error: fmt.Errorf("upstream rejected request with code %d", resp.StatusCode), code: http.StatusInternalServerError}
-	}
-	contentType := resp.Header.Get("Content-Type")
-	mediaType, _, err := mime.ParseMediaType(contentType)
-	if err != nil || mediaType != "application/json" {
-		log.Printf("warning: Upstream server %s responded with an unknown content type %q", a.to, contentType)
-		return "", fmt.Errorf("unrecognized token response content-type %q", contentType)
+		return nil
+	})
+	if err != nil {
+		return "", err
 	}
 
-	regResponse, err := tryReadResponse(resp.Body, 32*1024)
-	if err != nil {
+	response := &clusterRegistration{}
+	if err := json.Unmarshal(body, response); err != nil {
 		log.Printf("warning: Upstream server %s response could not be parsed", a.to)
 		return "", fmt.Errorf("unable to parse response body: %v", err)
 	}
 
-	if len(regResponse.AccountID) == 0 {
+	if len(response.AccountID) == 0 {
 		log.Printf("warning: Upstream server %s responded with an empty user string", a.to)
 		return "", fmt.Errorf("server responded with an empty user string")
 	}
 
-	return regResponse.AccountID, nil
-}
-
-func tryReadResponse(r io.Reader, limitBytes int64) (*clusterRegistration, error) {
-	body, err := ioutil.ReadAll(io.LimitReader(r, limitBytes))
-	if err != nil {
-		return nil, err
-	}
-	response := &clusterRegistration{}
-	if err := json.Unmarshal(body, response); err != nil {
-		return nil, err
-	}
-	return response, nil
-}
-
-type errWithCode struct {
-	error
-	code int
-}
-
-func (e errWithCode) HTTPStatusCode() int {
-	return e.code
-}
-
-func tryLogBody(r io.Reader, limitBytes int64, format string) {
-	body, _ := ioutil.ReadAll(io.LimitReader(r, limitBytes))
-	log.Printf(format, string(body))
+	return response.AccountID, nil
 }

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -1,0 +1,83 @@
+package receive
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+const forwardTimeout = 5 * time.Second
+
+// ClusterAuthorizer authorizes a cluster by its token and id, returning a subject or error
+type ClusterAuthorizer interface {
+	AuthorizeCluster(token, cluster string) (subject string, err error)
+}
+
+// Handler knows the forwardURL for all requests
+type Handler struct {
+	ForwardURL string
+	client     *http.Client
+}
+
+// NewHandler returns a new Handler with a http client
+func NewHandler(forwardURL string) *Handler {
+	return &Handler{
+		ForwardURL: forwardURL,
+		client: &http.Client{
+			Timeout: forwardTimeout,
+		},
+	}
+}
+
+// Receive a remote-write request after it has been authenticated and forward it to Thanos
+func (h *Handler) Receive(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	defer r.Body.Close()
+
+	ctx, cancel := context.WithTimeout(r.Context(), forwardTimeout)
+	defer cancel()
+
+	req, err := http.NewRequest(http.MethodPost, h.ForwardURL, r.Body)
+	if err != nil {
+		log.Printf("failed to create forward request: %v\n", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	req = req.WithContext(ctx)
+	req.Header.Add("THANOS-TENANT", "FOOBAR") // TODO: Get the tenant
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		log.Printf("failed to foward request: %v\n", err)
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	if resp.StatusCode/100 != 2 {
+		log.Printf("response status code is %s\n", resp.Status)
+		http.Error(w, "upstream response status is not 200 OK", http.StatusBadGateway)
+		return
+	}
+}
+
+// Authorizer is a middlware that uses a ClusterAuthorizer implementation to auth an incoming remote-write request.
+func (h *Handler) Authorizer(authorizer ClusterAuthorizer, next http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		subject, err := authorizer.AuthorizeCluster("", "")
+		if err != nil {
+			log.Printf("unauthorized request made: %v", err)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		fmt.Println(subject)
+
+		next.ServeHTTP(w, r)
+	}
+}

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -1,21 +1,15 @@
 package receive
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
-	"encoding/json"
-	"io/ioutil"
 	"log"
 	"net/http"
-	"strings"
 	"time"
+
+	"github.com/openshift/telemeter/pkg/authorize"
 )
 
-type clusterIDKey string
-
 const forwardTimeout = 5 * time.Second
-const clusterID clusterIDKey = "tenant"
 
 // ClusterAuthorizer authorizes a cluster by its token and id, returning a subject or error
 type ClusterAuthorizer interface {
@@ -57,7 +51,7 @@ func (h *Handler) Receive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	req = req.WithContext(ctx)
-	req.Header.Add("THANOS-TENANT", r.Context().Value(clusterID).(string))
+	req.Header.Add("THANOS-TENANT", r.Context().Value(authorize.TenantKey).(string))
 
 	resp, err := h.client.Do(req)
 	if err != nil {
@@ -70,45 +64,5 @@ func (h *Handler) Receive(w http.ResponseWriter, r *http.Request) {
 		log.Printf("response status code is %s\n", resp.Status)
 		http.Error(w, "upstream response status is not 200 OK", http.StatusBadGateway)
 		return
-	}
-}
-
-type AuthorizationPayload struct {
-	Cluster string `json:"cluster"`
-	Token   string `json:"token"`
-}
-
-// Authorizer is a middlware that uses a ClusterAuthorizer implementation to auth an incoming remote-write request.
-func (h *Handler) Authorizer(authorizer ClusterAuthorizer, next http.Handler) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		authHeader := r.Header.Get("Authorization")
-		authParts := strings.Split(string(authHeader), " ")
-		if len(authParts) != 2 || strings.ToLower(authParts[0]) != "bearer" {
-			http.Error(w, "bad authorization header", http.StatusBadRequest)
-			return
-		}
-
-		authHeaderDecoded, err := ioutil.ReadAll(base64.NewDecoder(base64.StdEncoding, bytes.NewBufferString(authParts[1])))
-		if err != nil {
-			http.Error(w, "failed base64 decoding authorization bearer", http.StatusBadRequest)
-			return
-		}
-
-		var authPayload AuthorizationPayload
-		if err := json.Unmarshal([]byte(authHeaderDecoded), &authPayload); err != nil {
-			http.Error(w, "failed to unmarshal authorization bearer", http.StatusBadRequest)
-			return
-		}
-
-		_, err = authorizer.AuthorizeCluster(authPayload.Token, authPayload.Cluster)
-		if err != nil {
-			log.Printf("unauthorized request made: %v", err)
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return
-		}
-
-		r = r.WithContext(context.WithValue(r.Context(), clusterID, authPayload.Cluster))
-
-		next.ServeHTTP(w, r)
 	}
 }


### PR DESCRIPTION
We want to add a remote-write receive handler to Telemeter.
For this we need to add a new authorizer, as we are unable to use JWTs.

Works with a mock authorization-server.
Here's a Prometheus config to test with:

```yaml
global:
  scrape_interval:     15s
  evaluation_interval: 15s

scrape_configs:
  - job_name: 'prometheus'
    static_configs:
    - targets: ['localhost:9090']
  - job_name: 'telemeter'
    static_configs:
    - targets: ['localhost:9004']

remote_write:
  - url: "http://localhost:9003/metrics/v1/receive"
    bearer_token: 'eyJjbHVzdGVyIjogImU1MGFiNGIwLTgwZjgtNDU3OC05NWVmLWQ0NzI5Njg5NzZhZSIsICJ0b2tlbiI6ICJhIn0K'
```

TODOs:
* [ ] Add some basic metrics (compare with forward store)

/cc @squat @brancz @kakkoyun 
