### PR TITLE
Add metric "knative_serving_health" to monitor health status of knative serving

### DIFF
--- a/docs/data-collection.md
+++ b/docs/data-collection.md
@@ -127,6 +127,8 @@ For the OpenShift 4 Developer Preview we will be sending back these exact attrib
   '{__name__="noobaa_total_usage"}',
   // console_url is the url of the console running on the cluster.
   '{__name__="console_url"}',
+  // knative_serving_health gives the health status of installed knative serving.
+  '{__name__="knative_serving_health"}',
 ]
 ```
 

--- a/jsonnet/telemeter/metrics.jsonnet
+++ b/jsonnet/telemeter/metrics.jsonnet
@@ -119,4 +119,6 @@
   '{__name__="noobaa_total_usage"}',
   // console_url is the url of the console running on the cluster.
   '{__name__="console_url"}',
+  // knative_serving_health gives the health status of knative serving.
+  '{__name__="knative_serving_health"}',
 ]

--- a/manifests/client/deployment.yaml
+++ b/manifests/client/deployment.yaml
@@ -66,6 +66,7 @@ spec:
         - --match={__name__="noobaa_accounts_num"}
         - --match={__name__="noobaa_total_usage"}
         - --match={__name__="console_url"}
+        - --match={__name__="knative_serving_health"}
         env:
         - name: ANONYMIZE_LABELS
           value: ""


### PR DESCRIPTION
knative serving operator expose metric called `knative_serving_health` which shows health status of installed knative serving

![image](https://user-images.githubusercontent.com/9441662/66342071-32d0ee00-e966-11e9-8ce7-bdf053183205.png)
