### PR TITLE
Bug 1744017: pkg/forwarder: dont proxy in-cluster requests

### DIFF
--- a/pkg/benchmark/benchmark.go
+++ b/pkg/benchmark/benchmark.go
@@ -153,6 +153,7 @@ func New(cfg *Config) (*Benchmark, error) {
 		}
 
 		transport := metricsclient.DefaultTransport()
+		transport.Proxy = http.ProxyFromEnvironment
 		if pool != nil {
 			if transport.TLSClientConfig == nil {
 				transport.TLSClientConfig = &tls.Config{}

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -167,7 +167,9 @@ func New(cfg Config) (*Worker, error) {
 	w.fromClient = metricsclient.New(fromClient, cfg.LimitBytes, w.interval, "federate_from")
 
 	// Create the `toClient`.
-	toClient := &http.Client{Transport: metricsclient.DefaultTransport()}
+	toTransport := metricsclient.DefaultTransport()
+	toTransport.Proxy = http.ProxyFromEnvironment
+	toClient := &http.Client{Transport: toTransport}
 	if cfg.Debug {
 		toClient.Transport = telemeterhttp.NewDebugRoundTripper(toClient.Transport)
 	}

--- a/pkg/metricsclient/metricsclient.go
+++ b/pkg/metricsclient/metricsclient.go
@@ -235,7 +235,6 @@ func withCancel(ctx context.Context, client *http.Client, req *http.Request, fn 
 
 func DefaultTransport() *http.Transport {
 	return &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,


### PR DESCRIPTION
Currently, requests to the in-cluster Prometheus respect the environment
variable proxy configuration just as requests to telemeter server
respect it. This means that when the proxy configuration is set,
requests to scrape the in-cluster prometheus will fail. This commit
fixes the configuration so only outbound requests are proxied.

cc @kakkoyun @metalmatze @s-urbaniak 