### PR TITLE
Bug 1746686: jsonnet: fix client reload port

### DIFF
--- a/manifests/client/deployment.yaml
+++ b/manifests/client/deployment.yaml
@@ -92,7 +92,7 @@ spec:
           name: secret-telemeter-client
           readOnly: false
       - args:
-        - --webhook-url=http://localhost:9000/-/reload
+        - --webhook-url=http://localhost:8080/-/reload
         - --volume-dir=/etc/serving-certs-ca-bundle
         image: quay.io/openshift/origin-configmap-reload:v3.11
         name: reload


### PR DESCRIPTION
The configmap reload for telemeter client was pointing to an unused port,
meaning that it would never reload anything.

cc @s-urbaniak @metalmatze @kakkoyun 