### PR TITLE
Bump prometheus-operator to 0.32

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter"
                 }
             },
-            "version": "7e3e02b2a756a5ed79cf12fbf3eba41f1a0d2f82"
+            "version": "c715d13aea5271586a324aa2dcbd8266fc83bd1a"
         },
         {
             "name": "ksonnet",

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter"
                 }
             },
-            "version": "ce5bcc9f18c048aa655842c22e5d1d465df6d1b5"
+            "version": "7e3e02b2a756a5ed79cf12fbf3eba41f1a0d2f82"
         },
         {
             "name": "ksonnet",

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/telemeter"
                 }
             },
-            "version": "e86c437d22dfec1b64a50a86e77993a976895c30"
+            "version": "ce5bcc9f18c048aa655842c22e5d1d465df6d1b5"
         },
         {
             "name": "ksonnet",
@@ -28,7 +28,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "f05d5228fe02bcd370acaa234c15f3d9fdef4a60"
+            "version": "d6ba399c064c47fea536f08d438a572588b256da"
         }
     ]
 }

--- a/jsonnet/telemeter/jsonnetfile.json
+++ b/jsonnet/telemeter/jsonnetfile.json
@@ -18,7 +18,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "release-0.31"
+            "version": "release-0.32"
         }
     ]
 }

--- a/manifests/benchmark/clusterRoleBindingPrometheusOperator.yaml
+++ b/manifests/benchmark/clusterRoleBindingPrometheusOperator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.31.0
+    app.kubernetes.io/version: v0.32.0
   name: telemeter-benchmark
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/benchmark/deploymentPrometheusOperator.yaml
+++ b/manifests/benchmark/deploymentPrometheusOperator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.31.0
+    app.kubernetes.io/version: v0.32.0
   name: prometheus-operator
   namespace: telemeter-benchmark
 spec:
@@ -18,15 +18,15 @@ spec:
       labels:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: prometheus-operator
-        app.kubernetes.io/version: v0.31.0
+        app.kubernetes.io/version: v0.32.0
     spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
         - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.31.0
-        image: quay.io/coreos/prometheus-operator:v0.31.0
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.32.0
+        image: quay.io/coreos/prometheus-operator:v0.32.0
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/manifests/benchmark/serviceAccountPrometheusOperator.yaml
+++ b/manifests/benchmark/serviceAccountPrometheusOperator.yaml
@@ -4,6 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.31.0
+    app.kubernetes.io/version: v0.32.0
   name: prometheus-operator
   namespace: telemeter-benchmark


### PR DESCRIPTION
We need this to bump prometheus-operator in CMO, currently, it fails as we have a mismatch of versions.

cc @s-urbaniak 