### PR TITLE
Add metalmatze to the list of OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -14,6 +14,7 @@ reviewers:
 - pbergene
 - riuvshin
 - skryzhny 
+- metalmatze
 
 approvers:
 - brancz
@@ -31,3 +32,4 @@ approvers:
 - pbergene
 - riuvshin
 - skryzhny
+- metalmatze


### PR DESCRIPTION
For some reason I thought I already was an owner/approver. Seems like this is still not the case :man_shrugging: 

/cc @squat