### PR TITLE
Add Oauth reference to prometheus telemeter SA

### DIFF
--- a/jsonnet/telemeter/prometheus/kubernetes.libsonnet
+++ b/jsonnet/telemeter/prometheus/kubernetes.libsonnet
@@ -43,6 +43,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       serviceAccount.mixin.metadata.withAnnotations({
         // TODO: Remove observatorium-thanos-querier once we have a separate clusterRole
         'serviceaccounts.openshift.io/oauth-redirectreference.observatorium-thanos-querier':'{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"observatorium-thanos-querier"}}',
+        'serviceaccounts.openshift.io/oauth-redirectreference.observatorium-thanos-querier-cache':'{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"observatorium-thanos-querier-cache"}}',
         'serviceaccounts.openshift.io/oauth-redirectreference.prometheus-k8s': '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"prometheus-telemeter"}}',
       }),
 

--- a/manifests/prometheus/list.yaml
+++ b/manifests/prometheus/list.yaml
@@ -218,6 +218,7 @@ objects:
   metadata:
     annotations:
       serviceaccounts.openshift.io/oauth-redirectreference.observatorium-thanos-querier: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"observatorium-thanos-querier"}}'
+      serviceaccounts.openshift.io/oauth-redirectreference.observatorium-thanos-querier-cache: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"observatorium-thanos-querier-cache"}}'
       serviceaccounts.openshift.io/oauth-redirectreference.prometheus-k8s: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"prometheus-telemeter"}}'
     name: prometheus-telemeter
     namespace: ${NAMESPACE}

--- a/manifests/prometheus/serviceAccount.yaml
+++ b/manifests/prometheus/serviceAccount.yaml
@@ -3,6 +3,7 @@ kind: ServiceAccount
 metadata:
   annotations:
     serviceaccounts.openshift.io/oauth-redirectreference.observatorium-thanos-querier: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"observatorium-thanos-querier"}}'
+    serviceaccounts.openshift.io/oauth-redirectreference.observatorium-thanos-querier-cache: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"observatorium-thanos-querier-cache"}}'
     serviceaccounts.openshift.io/oauth-redirectreference.prometheus-k8s: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"prometheus-telemeter"}}'
   name: prometheus-telemeter
   namespace: telemeter


### PR DESCRIPTION
Currently, we've been using the same SA for the querier and the prometheus auth proxy. 

This PR adds another route to this oauth reference: the querier cache route. This route will be the frontend for the querier and will cache client requests going into the querier. 