### PR TITLE
WIP: Add remote write config for subscription_labels

### DIFF
--- a/jsonnet/telemeter/prometheus/kubernetes.libsonnet
+++ b/jsonnet/telemeter/prometheus/kubernetes.libsonnet
@@ -230,6 +230,16 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
               pvc.mixin.spec.withStorageClassName('gp2-encrypted'),
           },
           listenLocal: true,
+          remoteWrite: [
+            {
+              url: "TODO",
+              write_relabel_configs: {
+                source_labels: ['__name__'],
+                        regex: 'subscription_labels',
+                        action: 'keep',
+              },
+            },
+          ],
           containers: [
             {
               name: 'prometheus-proxy',

--- a/manifests/prometheus/list.yaml
+++ b/manifests/prometheus/list.yaml
@@ -86,6 +86,13 @@ objects:
     listenLocal: true
     nodeSelector:
       beta.kubernetes.io/os: linux
+    remoteWrite:
+    - url: TODO
+      write_relabel_configs:
+        action: keep
+        regex: subscription_labels
+        source_labels:
+        - __name__
     replicas: 2
     resources:
       limits:

--- a/manifests/prometheus/prometheus.yaml
+++ b/manifests/prometheus/prometheus.yaml
@@ -38,6 +38,13 @@ spec:
   listenLocal: true
   nodeSelector:
     beta.kubernetes.io/os: linux
+  remoteWrite:
+  - url: TODO
+    write_relabel_configs:
+      action: keep
+      regex: subscription_labels
+      source_labels:
+      - __name__
   replicas: 2
   resources:
     limits: {}


### PR DESCRIPTION
This PR adds remote write config to Prometheus, to send `subscription labels` to Telemeter V2