### PR TITLE
Bug 1746711: fix client reload port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: all build image check test-generate test-integration test-benchmark vendor dependencies manifests
 
+SHELL=/bin/bash
 BIN=bin
 GOLANGCI_LINT_BIN=$(BIN)/golangci-lint
 EMBEDMD_BIN=$(GOPATH)/bin/embedmd
@@ -38,7 +39,7 @@ docs/telemeter_query: $(JSONNET_SRC)
 	echo "$$query" > $@
 
 test-generate:
-	make --always-make && git diff --exit-code
+	make manifests && git diff --exit-code
 
 lint: $(GOLANGCI_LINT_BIN)
 	# megacheck fails to respect build flags, causing compilation failure during linting.

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ docs/telemeter_query: $(JSONNET_SRC)
 	echo "$$query" > $@
 
 test-generate:
-	make manifests && git diff --exit-code
+	make manifests --always-make && git diff --exit-code
 
 lint: $(GOLANGCI_LINT_BIN)
 	# megacheck fails to respect build flags, causing compilation failure during linting.
@@ -89,17 +89,16 @@ $(JSONNET_VENDOR): jsonnet/jsonnetfile.json $(JB_BIN)
 dependencies: $(JB_BIN) $(JSONNET_BIN) $(GOLANGCI_LINT_BIN)
 
 $(JB_BIN):
-	go get -u github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
+	GO111MODULE=off go get -u github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
 
 $(JSONNET_BIN):
-	go get -u -d github.com/google/go-jsonnet/cmd/jsonnet
-	cd $(GOPATH)/src/github.com/google/go-jsonnet && git checkout v0.12.1 && git submodule update && go install -a ./jsonnet
+	GO111MODULE=off go get -u -d github.com/google/go-jsonnet/cmd/jsonnet
 
 $(GOLANGCI_LINT_BIN):
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(BIN) v1.10.2
 
 $(EMBEDMD_BIN):
-	go get -u github.com/campoy/embedmd
+	GO111MODULE=off go get -u github.com/campoy/embedmd
 
 $(GOJSONTOYAML_BIN):
-	go get -u github.com/brancz/gojsontoyaml
+	GO111MODULE=off go get -u github.com/brancz/gojsontoyaml

--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -3,12 +3,11 @@
         {
             "name": "telemeter",
             "source": {
-                "git": {
-                    "remote": "../",
-                    "subdir": "jsonnet/telemeter"
+                "local": {
+                    "directory": "telemeter"
                 }
             },
-            "version": "."
+            "version": ""
         }
     ]
 }

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -3,12 +3,11 @@
         {
             "name": "telemeter",
             "source": {
-                "git": {
-                    "remote": "../",
-                    "subdir": "jsonnet/telemeter"
+                "local": {
+                    "directory": "telemeter"
                 }
             },
-            "version": "e580d1f71da91e809c0f52dc6272536cf08605a9"
+            "version": ""
         },
         {
             "name": "ksonnet",
@@ -18,7 +17,7 @@
                     "subdir": ""
                 }
             },
-            "version": "d03da231d6c8bd74437b74a1e9e8b966f13dffa2"
+            "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f"
         },
         {
             "name": "prometheus-operator",
@@ -28,7 +27,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "bd5feacc528f0bcb69fb9167dacb2700eb75d322"
+            "version": "18fbf558ab7f8809fd610a3dc50bf483508dc1bb"
         }
     ]
 }

--- a/jsonnet/telemeter/client/kubernetes.libsonnet
+++ b/jsonnet/telemeter/client/kubernetes.libsonnet
@@ -9,7 +9,7 @@ local servingCertsCABundle = 'serving-certs-ca-bundle';
 local servingCertsCABundleFileName = 'service-ca.crt';
 local servingCertsCABundleMountPath = '/etc/%s' % servingCertsCABundle;
 local fromTokenFile = '/var/run/secrets/kubernetes.io/serviceaccount/token';
-local metricsPort = 8080;
+local insecurePort = 8080;
 local securePort = 8443;
 
 {
@@ -119,18 +119,18 @@ local securePort = 8443;
           '--from-token-file=' + fromTokenFile,
           '--to=$(TO)',
           '--to-token-file=%s/token' % secretMountPath,
-          '--listen=localhost:' + metricsPort,
+          '--listen=localhost:' + insecurePort,
           '--anonymize-salt-file=%s/salt' % secretMountPath,
           '--anonymize-labels=$(ANONYMIZE_LABELS)',
         ] + matchRules) +
-        container.withPorts(containerPort.newNamed('http', metricsPort)) +
+        container.withPorts(containerPort.newNamed('http', insecurePort)) +
         container.withVolumeMounts([sccabMount, secretMount]) +
         container.withEnv([anonymize, from, id, to]);
 
       local reload =
         container.new('reload', $._config.imageRepos.configmapReload + ':' + $._config.versions.configmapReload) +
         container.withArgs([
-          '--webhook-url=http://localhost:9000/-/reload',
+          '--webhook-url=http://localhost:%s/-/reload' % insecurePort,
           '--volume-dir=' + servingCertsCABundleMountPath,
         ]) +
         container.withVolumeMounts([sccabMount]);
@@ -139,7 +139,7 @@ local securePort = 8443;
         container.new('kube-rbac-proxy', $._config.imageRepos.kubeRbacProxy + ':' + $._config.versions.kubeRbacProxy) +
         container.withArgs([
           '--secure-listen-address=:' + securePort,
-          '--upstream=http://127.0.0.1:%s/' % metricsPort,
+          '--upstream=http://127.0.0.1:%s/' % insecurePort,
           '--tls-cert-file=%s/tls.crt' % tlsMountPath,
           '--tls-private-key-file=%s/tls.key' % tlsMountPath,
         ] + if std.objectHas($._config, 'tlsCipherSuites') then [
@@ -157,7 +157,7 @@ local securePort = 8443;
       deployment.mixin.spec.selector.withMatchLabels(podLabels) +
       deployment.mixin.spec.template.spec.withServiceAccountName('telemeter-client') +
       deployment.mixin.spec.template.spec.withPriorityClassName('system-cluster-critical') +
-      deployment.mixin.spec.template.spec.withNodeSelector({'beta.kubernetes.io/os': 'linux'}) +
+      deployment.mixin.spec.template.spec.withNodeSelector({ 'beta.kubernetes.io/os': 'linux' }) +
       deployment.mixin.spec.template.spec.withVolumes([sccabVolume, secretVolume, tlsVolume]),
 
     secret:

--- a/manifests/benchmark/clusterRoleBindingPrometheusOperator.yaml
+++ b/manifests/benchmark/clusterRoleBindingPrometheusOperator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     apps.kubernetes.io/component: controller
     apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.29.0
+    apps.kubernetes.io/version: v0.30.0
   name: prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/benchmark/deploymentPrometheusOperator.yaml
+++ b/manifests/benchmark/deploymentPrometheusOperator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     apps.kubernetes.io/component: controller
     apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.29.0
+    apps.kubernetes.io/version: v0.30.0
   name: prometheus-operator
   namespace: telemeter-benchmark
 spec:
@@ -18,15 +18,15 @@ spec:
       labels:
         apps.kubernetes.io/component: controller
         apps.kubernetes.io/name: prometheus-operator
-        apps.kubernetes.io/version: v0.29.0
+        apps.kubernetes.io/version: v0.30.0
     spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
         - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.29.0
-        image: quay.io/coreos/prometheus-operator:v0.29.0
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.30.0
+        image: quay.io/coreos/prometheus-operator:v0.30.0
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/manifests/benchmark/serviceAccountPrometheusOperator.yaml
+++ b/manifests/benchmark/serviceAccountPrometheusOperator.yaml
@@ -4,6 +4,6 @@ metadata:
   labels:
     apps.kubernetes.io/component: controller
     apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.29.0
+    apps.kubernetes.io/version: v0.30.0
   name: prometheus-operator
   namespace: telemeter-benchmark

--- a/manifests/client/deployment.yaml
+++ b/manifests/client/deployment.yaml
@@ -74,7 +74,7 @@ spec:
           name: secret-telemeter-client
           readOnly: false
       - args:
-        - --webhook-url=http://localhost:9000/-/reload
+        - --webhook-url=http://localhost:8080/-/reload
         - --volume-dir=/etc/serving-certs-ca-bundle
         image: quay.io/openshift/origin-configmap-reload:v3.11
         name: reload


### PR DESCRIPTION
The configmap reload for telemeter client was pointing to an unused port,
meaning that it would never reload anything.

Backport to the 4.1 release of https://github.com/openshift/telemeter/pull/229/files

cc @s-urbaniak @squat 