### PR TITLE
test/e2e: fix forward test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GO_PKG=github.com/openshift/telemeter
 REPO?=quay.io/openshift/telemeter
 TAG?=$(shell git rev-parse --short HEAD)
 
-PKGS=$(shell go list ./... | grep -v -E '/vendor/|/test')
+PKGS=$(shell go list ./... | grep -v -E '/vendor/|/test/(?!e2e)')
 GOLANG_FILES:=$(shell find . -name \*.go -print)
 FIRST_GOPATH:=$(firstword $(subst :, ,$(shell go env GOPATH)))
 GOLANGCI_LINT_BIN=$(FIRST_GOPATH)/bin/golangci-lint

--- a/test/e2e/forward_test.go
+++ b/test/e2e/forward_test.go
@@ -39,7 +39,7 @@ var expectedTimeSeries = []prompb.TimeSeries{
 			{Name: "job", Value: "test"},
 			{Name: "label", Value: "value0"},
 		},
-		Samples: []prompb.Sample{{Timestamp: 1562500000000, Value: 1}},
+		Samples: []prompb.Sample{{Value: 1}},
 	},
 	{
 		Labels: []prompb.Label{
@@ -48,7 +48,7 @@ var expectedTimeSeries = []prompb.TimeSeries{
 			{Name: "job", Value: "test"},
 			{Name: "label", Value: "value1"},
 		},
-		Samples: []prompb.Sample{{Timestamp: 1562600000000, Value: 1}},
+		Samples: []prompb.Sample{{Value: 1}},
 	},
 	{
 		Labels: []prompb.Label{
@@ -57,7 +57,7 @@ var expectedTimeSeries = []prompb.TimeSeries{
 			{Name: "job", Value: "test"},
 			{Name: "label", Value: "value2"},
 		},
-		Samples: []prompb.Sample{{Timestamp: 1562700000000, Value: 0}},
+		Samples: []prompb.Sample{{Value: 0}},
 	},
 }
 
@@ -181,9 +181,6 @@ func mockedReceiver(t *testing.T) http.HandlerFunc {
 			}
 			for j, s := range ts.Samples {
 				ws := wreq.Timeseries[i].Samples[j]
-				if s.Timestamp != ws.Timestamp {
-					t.Errorf("expected timestamp for sample %d, got %d", s.Timestamp, ws.Timestamp)
-				}
 				if s.Value != ws.Value {
 					t.Errorf("expected value for sample %2.f, got %2.f", s.Value, ws.Value)
 				}


### PR DESCRIPTION
The e2e tests were never being run as part of the CI workflow. Also,
because the e2e test files were excluded from the list of packages, they
were not statically checked.

All metrics received by the v1 ingester and forwarded will have their
timestamps overwritten by the validator, so it doesn't make sense to
ensure that the timestamp is unchanged.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @kakkoyun @metalmatze 