### PR TITLE
pkg/cluster: fix running telemeter without verbose

### DIFF
--- a/pkg/cluster/memberlist.go
+++ b/pkg/cluster/memberlist.go
@@ -45,6 +45,7 @@ func NewMemberlist(logger log.Logger, name, addr string, secret []byte, verbose 
 
 	if !verbose {
 		cfg.LogOutput = ioutil.Discard
+		cfg.Logger = nil
 	}
 
 	cfg.SecretKey = secret


### PR DESCRIPTION
Currently, if telemeter-server is run without the `-v` flag, it will
bail with the following error:
```
level=info caller=main.go:156 ts=2019-12-11T14:09:52.043501508Z msg="Telemeter server initialized."
level=error caller=main.go:159 ts=2019-12-11T14:09:52.221533957Z err="unable to configure cluster: Cannot specify both LogOutput and Logger. Please choose a single log configuration setting."
```

This commit fixes the configuration of the logger for memberlist so that
it telemeter-server can be run without `-v`.

XREF: https://github.com/openshift/telemeter/pull/237

cc @kakkoyun @metalmatze @brancz @bwplotka 

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>