### PR TITLE
jsonnet/telemeter: fix memcached replica offset

### DIFF
--- a/jsonnet/telemeter/server.libsonnet
+++ b/jsonnet/telemeter/server.libsonnet
@@ -11,6 +11,11 @@ local list = import 'lib/list.libsonnet';
           + list.withResourceRequestsAndLimits('telemeter-server', $._config.telemeterServer.resourceRequests, $._config.telemeterServer.resourceLimits),
   },
   memcached+:: {
+    service+: {
+      metadata+: {
+        namespace: '${NAMESPACE}',
+      },
+    },
     list: list.asList('memcached', m, [
             {
               name: 'MEMCACHED_IMAGE',

--- a/jsonnet/telemeter/server/kubernetes.libsonnet
+++ b/jsonnet/telemeter/server/kubernetes.libsonnet
@@ -61,7 +61,7 @@ local clusterPort = 8082;
         $._config.telemeterServer.elideLabels
       );
 
-      local memcachedReplicas = std.range(1, $.memcached.replicas);
+      local memcachedReplicas = std.range(0, $.memcached.replicas - 1);
       local memcached = [
         '--memcached=%s-%d.%s.%s.svc.cluster.local:%d' % [
           $.memcached.statefulSet.metadata.name,


### PR DESCRIPTION
This commit corrects the offset of the Memcached replica names.
StatefulSet replica names begin with `0` not `1`.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @bwplotka @metalmatze @brancz 