### PR TITLE
pkg/cache: update memcached dns on interval

### DIFF
--- a/pkg/cache/memcached/memcached.go
+++ b/pkg/cache/memcached/memcached.go
@@ -1,8 +1,11 @@
 package memcached
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/pkg/errors"
@@ -12,17 +15,38 @@ import (
 
 // cache is a Cacher implemented on top of Memcached.
 type cache struct {
-	*memcache.Client
+	client     *memcache.Client
 	expiration int32
+	mu         sync.RWMutex
 }
 
-// New creates a new Cache from a list of Memcached servers
-// and key expiration time given in seconds.
-func New(expiration int32, servers ...string) tcache.Cacher {
-	return &cache{
-		memcache.New(servers...),
-		expiration,
+// New creates a new Cacher from a list of Memcached servers,
+// a key expiration time given in seconds, a DNS refresh interval,
+// and a context. The Cacher will continue to update the DNS entries
+// for the Memcached servers every interval as long as the context is valid.
+func New(ctx context.Context, interval, expiration int32, servers ...string) tcache.Cacher {
+	c := &cache{
+		client:     memcache.New(servers...),
+		expiration: expiration,
 	}
+
+	if interval > 0 {
+		go func() {
+			t := time.NewTicker(time.Duration(interval) * time.Second)
+			for {
+				select {
+				case <-t.C:
+					c.mu.Lock()
+					c.client = memcache.New(servers...)
+					c.mu.Unlock()
+				case <-ctx.Done():
+					t.Stop()
+					return
+				}
+			}
+		}()
+	}
+	return c
 }
 
 // Get returns a value from Memcached.
@@ -31,7 +55,9 @@ func (c *cache) Get(key string) ([]byte, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
-	i, err := c.Client.Get(key)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	i, err := c.client.Get(key)
 	if err != nil {
 		if err == memcache.ErrCacheMiss {
 			return nil, false, nil
@@ -53,7 +79,9 @@ func (c *cache) Set(key string, value []byte) error {
 		Value:      value,
 		Expiration: c.expiration,
 	}
-	return c.Client.Set(&i)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.client.Set(&i)
 }
 
 // hashKey hashes the given key to ensure that it is less than 250 bytes,


### PR DESCRIPTION
We need to be able to update the DNS for the Memcached DNS servers
to keep up with changes in the IPs of the servers. This implements a
simple time-based DNS update.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @metalmatze @brancz @kakkoyun 