### PR TITLE
Receive requests are required to have partitionKey label

### DIFF
--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -379,7 +379,7 @@ func (o *Options) Run() error {
 	transforms.With(metricfamily.NewElide(o.ElideLabels...))
 
 	server := httpserver.New(o.Logger, store, validator, transforms)
-	receiver := receive.NewHandler(o.Logger, o.ForwardURL, prometheus.DefaultRegisterer)
+	receiver := receive.NewHandler(o.Logger, o.ForwardURL, o.PartitionKey, prometheus.DefaultRegisterer)
 
 	internalPathJSON, _ := json.MarshalIndent(Paths{Paths: []string{"/", "/metrics", "/debug/pprof", "/healthz", "/healthz/ready"}}, "", "  ")
 	externalPathJSON, _ := json.MarshalIndent(Paths{Paths: []string{"/", "/authorize", "/upload", "/healthz", "/healthz/ready", "/metrics/v1/receive"}}, "", "  ")

--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -135,11 +135,7 @@ func main() {
 	cmd.Flags().StringVar(&opt.LogLevel, "log-level", opt.LogLevel, "Log filtering level. e.g info, debug, warn, error")
 
 	l := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	lvl, err := cmd.Flags().GetString("log-level")
-	if err != nil {
-		level.Error(l).Log("msg", "could not parse log-level.")
-	}
-	l = level.NewFilter(l, logger.LogLevelFromString(lvl))
+	l = level.NewFilter(l, logger.LogLevelFromString(opt.LogLevel))
 	l = log.WithPrefix(l, "ts", log.DefaultTimestampUTC)
 	l = log.WithPrefix(l, "caller", log.DefaultCaller)
 	stdlog.SetOutput(log.NewStdlibAdapter(l))
@@ -434,8 +430,9 @@ func (o *Options) Run() error {
 			authorize.NewHandler(o.Logger, &v2AuthorizeClient, authorizeURL, o.TenantKey,
 				receive.LimitBodySize(receive.RequestLimit,
 					receive.ValidateLabels(
+						o.Logger,
 						http.HandlerFunc(receiver.Receive),
-						"__name__", o.PartitionKey, // TODO: Enforce the same labels for v1 and v2
+						o.PartitionKey, // TODO: Enforce the same labels for v1 and v2
 					),
 				),
 			),

--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -432,9 +432,11 @@ func (o *Options) Run() error {
 	external.Handle("/metrics/v1/receive",
 		telemeter_http.NewInstrumentedHandler("receive",
 			authorize.NewHandler(o.Logger, &v2AuthorizeClient, authorizeURL, o.TenantKey,
-				receive.ValidateLabels(
-					http.HandlerFunc(receiver.Receive),
-					"__name__", o.PartitionKey, // TODO: Enforce the same labels for v1 and v2
+				receive.LimitBodySize(receive.RequestLimit,
+					receive.ValidateLabels(
+						http.HandlerFunc(receiver.Receive),
+						"__name__", o.PartitionKey, // TODO: Enforce the same labels for v1 and v2
+					),
 				),
 			),
 		),

--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -432,7 +432,9 @@ func (o *Options) Run() error {
 	external.Handle("/metrics/v1/receive",
 		telemeter_http.NewInstrumentedHandler("receive",
 			authorize.NewHandler(o.Logger, &v2AuthorizeClient, authorizeURL, o.TenantKey,
-				http.HandlerFunc(receiver.Receive),
+				receiver.ValidateLabels(
+					http.HandlerFunc(receiver.Receive),
+				),
 			),
 		),
 	)

--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -428,7 +428,7 @@ func (o *Options) Run() error {
 	external.Handle("/metrics/v1/receive",
 		telemeter_http.NewInstrumentedHandler("receive",
 			authorize.NewHandler(o.Logger, &v2AuthorizeClient, authorizeURL, o.TenantKey,
-				receive.LimitBodySize(receive.RequestLimit,
+				receive.LimitBodySize(receive.DefaultRequestLimit,
 					receive.ValidateLabels(
 						o.Logger,
 						http.HandlerFunc(receiver.Receive),

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -67,6 +67,8 @@ func (h *Handler) Receive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	defer r.Body.Close()
+
 	// Limit the request body size to a sane default
 	r.Body = http.MaxBytesReader(w, r.Body, requestLimit)
 

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -131,21 +131,21 @@ func (h *Handler) ValidateLabels(next http.Handler) http.HandlerFunc {
 			return
 		}
 
-		found := false
 		for _, ts := range wreq.GetTimeseries() {
+			found := false
 			for _, l := range ts.GetLabels() {
 				if l.Name == h.PartitionKey {
 					found = true
 					break
 				}
 			}
+
+			if !found {
+				http.Error(w, ErrRequiredLabelMissing.Error(), http.StatusBadRequest)
+				return
+			}
 		}
 
-		if found {
-			next.ServeHTTP(w, r)
-			return
-		}
-
-		http.Error(w, ErrRequiredLabelMissing.Error(), http.StatusBadRequest)
+		next.ServeHTTP(w, r)
 	}
 }

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -104,6 +104,7 @@ func (h *Handler) Receive(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(resp.StatusCode)
 }
 
+// ErrRequiredLabelMissing is returned if a required label is missing from a metric
 var ErrRequiredLabelMissing = fmt.Errorf("a required label is missing from the metric")
 
 // ValidateLabels makes sure that the request's content contains the required partitionKey

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -1,7 +1,6 @@
 package receive
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -127,16 +126,14 @@ func ValidateLabels(next http.Handler, labels ...string) http.HandlerFunc {
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		r.Body = ioutil.NopCloser(r.Body)
+		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, "failed to read body", http.StatusInternalServerError)
 			return
 		}
-		r.Body.Close()
 
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
-		body, err := ioutil.ReadAll(r.Body)
+		r.Body.Close()
 
 		content, err := snappy.Decode(nil, body)
 		if err != nil {

--- a/test/e2e/forward_test.go
+++ b/test/e2e/forward_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -137,6 +138,7 @@ func readMetrics(m string) []*clientmodel.MetricFamily {
 
 func fakeAuthorizeHandler(h http.Handler, client *authorize.Client) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		req = req.WithContext(context.WithValue(req.Context(), authorize.TenantKey, client.ID))
 		req = req.WithContext(authorize.WithClient(req.Context(), client))
 		h.ServeHTTP(w, req)
 	})

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -87,6 +87,7 @@ func TestReceiveValidateLabels(t *testing.T) {
 		telemeterServer = httptest.NewServer(
 			fakeAuthorizeHandler(
 				receive.ValidateLabels(
+					log.NewNopLogger(),
 					http.HandlerFunc(receiver.Receive),
 					"__name__",
 				),

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -136,7 +136,7 @@ func TestLimitBodySize(t *testing.T) {
 
 		telemeterServer = httptest.NewServer(
 			fakeAuthorizeHandler(
-				receive.LimitBodySize(receive.RequestLimit,
+				receive.LimitBodySize(receive.DefaultRequestLimit,
 					http.HandlerFunc(receiver.Receive),
 				),
 				&authorize.Client{ID: "test"},

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -1,0 +1,121 @@
+package e2e
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
+	"github.com/openshift/telemeter/pkg/authorize"
+	"github.com/openshift/telemeter/pkg/receive"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/prompb"
+)
+
+func TestReceiveValidateLabels(t *testing.T) {
+	testcases := []struct {
+		Name             string
+		Timeseries       []prompb.TimeSeries
+		ExpectStatusCode int
+	}{
+		{
+			Name: "NoLabels",
+			Timeseries: []prompb.TimeSeries{{
+				Labels: []prompb.Label{},
+			}},
+			ExpectStatusCode: http.StatusBadRequest,
+		},
+		{
+			Name: "MissingRequiredLabel",
+			Timeseries: []prompb.TimeSeries{{
+				Labels: []prompb.Label{{Name: "foo", Value: "bar"}},
+			}},
+			ExpectStatusCode: http.StatusBadRequest,
+		},
+		{
+			Name: "Valid",
+			Timeseries: []prompb.TimeSeries{{
+				Labels: []prompb.Label{{Name: "__name__", Value: "foo"}},
+			}},
+			ExpectStatusCode: http.StatusOK,
+		},
+		{
+			Name: "MultipleMissingRequiredLabel",
+			Timeseries: []prompb.TimeSeries{{
+				Labels: []prompb.Label{{Name: "foo", Value: "bar"}},
+			}, {
+				Labels: []prompb.Label{{Name: "bar", Value: "baz"}},
+			}},
+			ExpectStatusCode: http.StatusBadRequest,
+		},
+		{
+			Name: "OneMultipleMissingRequiredLabel",
+			Timeseries: []prompb.TimeSeries{{
+				Labels: []prompb.Label{{Name: "foo", Value: "bar"}},
+			}, {
+				Labels: []prompb.Label{{Name: "__name__", Value: "foo"}},
+			}},
+			ExpectStatusCode: http.StatusBadRequest,
+		},
+		{
+			Name: "MultipleValid",
+			Timeseries: []prompb.TimeSeries{{
+				Labels: []prompb.Label{{Name: "__name__", Value: "foo"}},
+			}, {
+				Labels: []prompb.Label{{Name: "__name__", Value: "bar"}},
+			}},
+			ExpectStatusCode: http.StatusOK,
+		},
+	}
+
+	var receiveServer *httptest.Server
+	{
+		receiveServer = httptest.NewServer(func() http.HandlerFunc {
+			return func(w http.ResponseWriter, r *http.Request) {}
+		}())
+		defer receiveServer.Close()
+	}
+
+	var telemeterServer *httptest.Server
+	{
+		receiver := receive.NewHandler(log.NewNopLogger(), receiveServer.URL, prometheus.DefaultRegisterer)
+
+		telemeterServer = httptest.NewServer(
+			fakeAuthorizeHandler(
+				receive.ValidateLabels(
+					http.HandlerFunc(receiver.Receive),
+					"__name__",
+				),
+				&authorize.Client{ID: "test"},
+			),
+		)
+
+		defer telemeterServer.Close()
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			wreq := &prompb.WriteRequest{Timeseries: tc.Timeseries}
+			data, err := proto.Marshal(wreq)
+			if err != nil {
+				t.Error("failed to marshal proto message")
+			}
+			compressed := snappy.Encode(nil, data)
+
+			resp, err := http.Post(telemeterServer.URL+"/metrics/v1/receive", "", bytes.NewBuffer(compressed))
+			if err != nil {
+				t.Error("failed to send the receive request: %w", err)
+			}
+			defer resp.Body.Close()
+
+			body, _ := ioutil.ReadAll(resp.Body)
+			if resp.StatusCode != tc.ExpectStatusCode {
+				t.Errorf("request did not return %d, but %s: %s", tc.ExpectStatusCode, resp.Status, string(body))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Let's decode the receive requests and check if the partitionKey (for us mostly `_id`) is available in the request and otherwise reject the request.