### PR TITLE
jsonnet/telemeter: monitor memcached

### DIFF
--- a/jsonnet/telemeter/server.libsonnet
+++ b/jsonnet/telemeter/server.libsonnet
@@ -3,26 +3,42 @@ local list = import 'lib/list.libsonnet';
 (import 'server/kubernetes.libsonnet') + {
   local ts = super.telemeterServer,
   local m = super.memcached,
+  local tsList = list.asList('telemeter', ts, [])
+                 + list.withAuthorizeURL($._config)
+                 + list.withNamespace($._config)
+                 + list.withServerImage($._config)
+                 + list.withResourceRequestsAndLimits('telemeter-server', $._config.telemeterServer.resourceRequests, $._config.telemeterServer.resourceLimits),
+  local mList = list.asList('memcached', m, [
+                  {
+                    name: 'MEMCACHED_IMAGE',
+                    value: m.images.memcached,
+                  },
+                  {
+                    name: 'MEMCACHED_IMAGE_TAG',
+                    value: m.tags.memcached,
+                  },
+                  {
+                    name: 'MEMCACHED_EXPORTER_IMAGE',
+                    value: m.images.exporter,
+                  },
+                  {
+                    name: 'MEMCACHED_EXPORTER_IMAGE_TAG',
+                    value: m.tags.exporter,
+                  },
+                ])
+                + list.withResourceRequestsAndLimits('memcached', $.memcached.resourceRequests, $.memcached.resourceLimits)
+                + list.withNamespace($._config),
+
   telemeterServer+:: {
-    list: list.asList('telemeter', ts, [])
-          + list.withAuthorizeURL($._config)
-          + list.withNamespace($._config)
-          + list.withServerImage($._config)
-          + list.withResourceRequestsAndLimits('telemeter-server', $._config.telemeterServer.resourceRequests, $._config.telemeterServer.resourceLimits),
-  },
-  memcached+:: {
-    service+: {
-      metadata+: {
-        namespace: '${NAMESPACE}',
-      },
+    list: list.asList('telemeter', {}, []) + {
+      objects:
+        tsList.objects +
+        mList.objects,
+
+      parameters:
+        tsList.parameters +
+        mList.parameters,
     },
-    list: list.asList('memcached', m, [
-            {
-              name: 'MEMCACHED_IMAGE',
-              value: m.image,
-            },
-          ])
-          + list.withNamespace($._config),
   },
 } + {
   _config+:: {


### PR DESCRIPTION
This commit introduces the memcached-exporter so that we can monitor
memcached. It also introduces some controls on the memcached process,
modeled after the grafana memcached jsonnet library:
https://github.com/grafana/jsonnet-libs/tree/master/memcached.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @metalmatze @brancz @kakkoyun 