### PR TITLE
test: use UP for querying in integration test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/memberlist v0.1.5
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jsonnet-bundler/jsonnet-bundler v0.2.0
-	github.com/observatorium/up v0.0.0-20191211124247-2187e5c6701d
+	github.com/observatorium/up v0.0.0-20200109183502-89757a581729
 	github.com/oklog/run v1.0.0
 	github.com/pkg/errors v0.8.1
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect

--- a/go.sum
+++ b/go.sum
@@ -453,8 +453,6 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/observatorium/up v0.0.0-20191211124247-2187e5c6701d h1:3TesJWOwsgYtbpk9gc/NyRGhcOUbWaFtA4I7iA6yDKw=
-github.com/observatorium/up v0.0.0-20191211124247-2187e5c6701d/go.mod h1:2S/xXiN2sSQFDGBA5Nk0l2ppt2Yf1Ukch0inzx14yig=
 github.com/observatorium/up v0.0.0-20200109183502-89757a581729 h1:1QXYFd80gTWcKClpx+bDfDRGO7lkBm0x+OiGxPI4Bxc=
 github.com/observatorium/up v0.0.0-20200109183502-89757a581729/go.mod h1:peD5Jv7R1C+3k7jqQr7AV2JZh1p4qy6N9jQKm6QjYoA=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=

--- a/go.sum
+++ b/go.sum
@@ -455,6 +455,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/observatorium/up v0.0.0-20191211124247-2187e5c6701d h1:3TesJWOwsgYtbpk9gc/NyRGhcOUbWaFtA4I7iA6yDKw=
 github.com/observatorium/up v0.0.0-20191211124247-2187e5c6701d/go.mod h1:2S/xXiN2sSQFDGBA5Nk0l2ppt2Yf1Ukch0inzx14yig=
+github.com/observatorium/up v0.0.0-20200109183502-89757a581729 h1:1QXYFd80gTWcKClpx+bDfDRGO7lkBm0x+OiGxPI4Bxc=
+github.com/observatorium/up v0.0.0-20200109183502-89757a581729/go.mod h1:peD5Jv7R1C+3k7jqQr7AV2JZh1p4qy6N9jQKm6QjYoA=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v0.0.0-20170117200651-66bb6560562f/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=

--- a/test/integration-v2.sh
+++ b/test/integration-v2.sh
@@ -6,7 +6,8 @@
 
 set -euo pipefail
 
-trap 'kill $(jobs -p); exit 0' EXIT
+result=1
+trap 'kill $(jobs -p); exit $result' EXIT
 
 ( ./authorization-server localhost:9001 ./test/tokens.json ) &
 
@@ -23,15 +24,6 @@ trap 'kill $(jobs -p); exit 0' EXIT
     -v
 ) &
 
-( 
-up \
-    --endpoint=http://127.0.0.1:9003/metrics/v1/receive \
-    --period=1s \
-    --name cluster_installer \
-    --labels '_id="test"' \
-    --token="$(echo '{"authorization_token":"a","cluster_id":"test"}' | base64)"
-) &
-
 (
 thanos receive \
     --tsdb.path="$(mktemp -d)" \
@@ -46,23 +38,26 @@ thanos query \
     --store=127.0.0.1:9006
 ) &
 
-sleep 1
+echo "waiting for dependencies to come up..."
+sleep 5
 
-retries=100
-while true; do 
-  if [[ "${retries}" -lt 0 ]]; then
-    echo "error: Did not successfully retrieve cluster metrics from the local Thanos query server" 1>&2
-    exit 1
-  fi
-  # verify we scrape metrics from the test cluster and give it _id test
-  if [[ "$( curl http://localhost:9008/api/v1/query --data-urlencode 'query=count({_id="test"})' -G 2>/dev/null | python3 -c 'import sys, json; print(json.load(sys.stdin)["data"]["result"][0]["value"][1])' 2>/dev/null )" -eq 0 ]]; then
-    retries=$((retries-1))
-    sleep 1
-    continue
-  fi
-  break
-done
-echo "tests: ok"
-exit 0
+if up \
+    --endpoint-write=http://127.0.0.1:9003/metrics/v1/receive \
+    --endpoint-read=http://127.0.0.1:9008/api/v1/query \
+    --period=500ms \
+    --initial-query-delay=250ms \
+    --threshold=1 \
+    --latency=10s \
+    --duration=10s \
+    --log.level=debug \
+    --name cluster_installer \
+    --labels '_id="test"' \
+    --token="$(echo '{"authorization_token":"a","cluster_id":"test"}' | base64)"; then
+    result=0
+    echo "tests: ok"
+    exit 0
+fi
 
-for i in `jobs -p`; do wait $i; done
+echo "tests: failed" 1>&2
+result=1
+exit 1

--- a/test/integration-v2.sh
+++ b/test/integration-v2.sh
@@ -11,7 +11,7 @@ trap 'kill $(jobs -p); exit $result' EXIT
 
 ( ./authorization-server localhost:9001 ./test/tokens.json ) &
 
-( memcached ) &
+( memcached -u "$(whoami)") &
 
 ( 
 ./telemeter-server \

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -19,7 +19,8 @@ else
   test="${TEST:-1}"
 fi
 
-trap 'kill $(jobs -p); exit 0' EXIT
+result=1
+trap 'kill $(jobs -p); exit $result' EXIT
 
 ( ./authorization-server localhost:9001 ./test/tokens.json ) &
 
@@ -106,7 +107,10 @@ if [[ -n "${test-}" ]]; then
     break
   done
   echo "tests: ok"
+  result=0
   exit 0
 fi
 
-for i in `jobs -p`; do wait $i; done
+echo "tests: failed" 1>&2
+result=1
+exit 1

--- a/vendor/github.com/observatorium/up/.drone.yml
+++ b/vendor/github.com/observatorium/up/.drone.yml
@@ -18,11 +18,11 @@ steps:
     GO111MODULE: on
     GOPROXY: https://proxy.golang.org
 
-- name: fmt
+- name: lint
   pull: always
   image: golang:1.13
   commands:
-  - fmt_res=$(gofmt -d -s $(find . -type f -name '*.go' -not -path './vendor/*')); if [ -n "$fmt_res" ]; then printf '\nGofmt found style issues. Please check the reported issues\nand fix them if necessary before submitting the code for review:\n\n%s' "$fmt_res"; exit 1; fi
+  - make lint
 
 - name: build
   pull: always
@@ -33,6 +33,13 @@ steps:
     CGO_ENABLED: 0
     GO111MODULE: on
     GOPROXY: https://proxy.golang.org
+
+- name: generate
+  pull: always
+  image: golang:1.13
+  commands:
+    - make README.md
+    - git diff --exit-code
 
 - name: tags
   image: golang:1.13

--- a/vendor/github.com/observatorium/up/.errcheck_excludes
+++ b/vendor/github.com/observatorium/up/.errcheck_excludes
@@ -1,0 +1,1 @@
+(github.com/go-kit/kit/log.Logger).Log

--- a/vendor/github.com/observatorium/up/.gitignore
+++ b/vendor/github.com/observatorium/up/.gitignore
@@ -1,3 +1,4 @@
 /up
 /.tags
 /vendor
+/tmp

--- a/vendor/github.com/observatorium/up/.golangci.yml
+++ b/vendor/github.com/observatorium/up/.golangci.yml
@@ -1,0 +1,17 @@
+run:
+  # default concurrency is a available CPU number
+  concurrency: 4
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  deadline: 3m
+  tests: true
+
+linters-settings:
+  errcheck:
+    exclude: .errcheck_excludes
+  lll:
+    line-length: 140
+  funlen:
+    lines: 120
+    statements: 45
+  gocognit:
+    min-complexity: 40

--- a/vendor/github.com/observatorium/up/Makefile
+++ b/vendor/github.com/observatorium/up/Makefile
@@ -1,0 +1,48 @@
+FIRST_GOPATH := $(firstword $(subst :, ,$(shell go env GOPATH)))
+EMBEDMD ?= $(FIRST_GOPATH)/bin/embedmd
+GOLANGCILINT ?= $(FIRST_GOPATH)/bin/golangci-lint
+GOLANGCILINT_VERSION ?= v1.21.0
+
+all: build
+
+build: up
+
+.PHONY: up
+up:
+	CGO_ENABLED=0 go build -v -ldflags '-w -extldflags '-static''
+
+.PHONY: format
+format: $(GOLANGCILINT) go-fmt
+	$(GOLANGCILINT) run --fix --enable-all -c .golangci.yml
+
+.PHONY: go-fmt
+go-fmt:
+	@fmt_res=$$(gofmt -d -s $$(find . -type f -name '*.go' -not -path './vendor/*' -not -path './jsonnet/vendor/*')); if [ -n "$$fmt_res" ]; then printf '\nGofmt found style issues. Please check the reported issues\nand fix them if necessary before submitting the code for review:\n\n%s' "$$fmt_res"; exit 1; fi
+
+.PHONY: lint
+lint: $(GOLANGCILINT)
+	$(GOLANGCILINT) run -v --enable-all -c .golangci.yml
+
+container: Dockerfile up
+	docker build -t quay.io/observatorium/up:latest .
+
+.PHONY: clean
+clean:
+	-rm tmp/help.txt
+	-rm ./up
+
+tmp/help.txt: clean build
+	mkdir -p tmp
+	-./up --help >tmp/help.txt 2>&1
+
+.PHONY: README.md
+README.md: $(EMBEDMD) tmp/help.txt
+	$(EMBEDMD) -w README.md
+
+$(EMBEDMD):
+	GO111MODULE=off go get -u github.com/campoy/embedmd
+
+$(GOLANGCILINT):
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCILINT_VERSION)/install.sh \
+		| sed -e '/install -d/d' \
+		| sh -s -- -b $(FIRST_GOPATH)/bin $(GOLANGCILINT_VERSION)

--- a/vendor/github.com/observatorium/up/README.md
+++ b/vendor/github.com/observatorium/up/README.md
@@ -4,6 +4,10 @@ UP is a simple client that makes Prometheus remote-write requests.
 The client writes the specified metric at the chosen interval.
 The value of the metric will always be the current timestamp in milliseconds.
 
+It can also read the value back and compare it against the current time.
+If the duration is greater than 0s, it will evaluate number of errors and success
+in the given duration against a percentage threshold and exit with zero or non-zero.
+
 [![Build Status](https://cloud.drone.io/api/badges/observatorium/up/status.svg)](https://cloud.drone.io/observatorium/up)
 
 ## Getting Started
@@ -20,4 +24,35 @@ For example, to report a metric named `foo` with a custom `bar` label, run:
 
 ```shell
 docker run --rm -p 8080:8080 quay.io/observatorium/up --endpoint=https://example.com/api/v1/receive --period=10s --name foo --labels 'bar="baz"'
+```
+
+## Usage
+
+[embedmd]:# (tmp/help.txt)
+```txt
+Usage of ./up:
+  -duration duration
+    	The duration of the up command to run until it stops. (default 5m0s)
+  -endpoint-read string
+    	The endpoint to which to make query requests.
+  -endpoint-write string
+    	The endpoint to which to make remote-write requests.
+  -initial-query-delay duration
+    	The time to wait before executing the first query. (default 5s)
+  -labels value
+    	The labels in addition to '__name__' that should be applied to remote-write requests.
+  -latency duration
+    	The maximum allowable latency between writing and reading. (default 15s)
+  -listen string
+    	The address on which internal server runs. (default ":8080")
+  -log.level string
+    	The log filtering level. Options: 'error', 'warn', 'info', 'debug'. (default "info")
+  -name string
+    	The name of the metric to send in remote-write requests. (default "up")
+  -period duration
+    	The time to wait between remote-write requests. (default 5s)
+  -threshold float
+    	The percentage of successful requests needed to succeed overall. 0 - 1. (default 0.9)
+  -token string
+    	The bearer token to set in the authorization header on remote-write requests.
 ```

--- a/vendor/github.com/observatorium/up/go.mod
+++ b/vendor/github.com/observatorium/up/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/oklog/run v1.0.0
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0
+	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
 	github.com/prometheus/common v0.6.0
 	github.com/prometheus/prometheus v0.0.0-20190819201610-48b2c9c8eae2
 )

--- a/vendor/github.com/observatorium/up/main.go
+++ b/vendor/github.com/observatorium/up/main.go
@@ -3,7 +3,11 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
 	stdlog "log"
 	"net/http"
 	"net/http/pprof"
@@ -21,94 +25,134 @@ import (
 	"github.com/golang/snappy"
 	"github.com/oklog/run"
 	"github.com/pkg/errors"
+	promapi "github.com/prometheus/client_golang/api"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
-)
-
-var (
-	remoteWriteRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "up_remote_writes_total",
-		Help: "Total number of remote write requests.",
-	},
-		[]string{"result"},
-	)
 )
 
 type labelArg []prompb.Label
 
 func (la *labelArg) String() string {
-	var ls []string
-	for _, l := range *la {
-		ls = append(ls, l.Name+"="+l.Value)
+	ls := make([]string, len(*la))
+	for i, l := range *la {
+		ls[i] = l.Name + "=" + l.Value
 	}
+
 	return strings.Join(ls, ", ")
 }
 
 func (la *labelArg) Set(v string) error {
-	var lset []prompb.Label
-	for _, l := range strings.Split(v, ",") {
+	labels := strings.Split(v, ",")
+	lset := make([]prompb.Label, len(labels))
+
+	for i, l := range labels {
 		parts := strings.SplitN(l, "=", 2)
 		if len(parts) != 2 {
 			return errors.Errorf("unrecognized label %q", l)
 		}
-		if !model.LabelName.IsValid(model.LabelName(string(parts[0]))) {
+
+		if !model.LabelName.IsValid(model.LabelName(parts[0])) {
 			return errors.Errorf("unsupported format for label %s", l)
 		}
+
 		val, err := strconv.Unquote(parts[1])
 		if err != nil {
 			return errors.Wrap(err, "unquote label value")
 		}
-		lset = append(lset, prompb.Label{Name: parts[0], Value: val})
+
+		lset[i] = prompb.Label{Name: parts[0], Value: val}
 	}
-	*la = labelArg(lset)
+
+	*la = lset
+
 	return nil
 }
 
-func main() {
-	opts := struct {
-		Endpoint string
-		Labels   labelArg
-		Listen   string
-		Name     string
-		Period   string
-		Token    string
+type queryResult struct {
+	Type   model.ValueType `json:"resultType"`
+	Result interface{}     `json:"result"`
+
+	v model.Value
+}
+
+func (qr *queryResult) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Status string `json:"status"`
+		Data   struct {
+			Type   model.ValueType `json:"resultType"`
+			Result json.RawMessage `json:"result"`
+		} `json:"data"`
 	}{}
 
-	flag.StringVar(&opts.Endpoint, "endpoint", "", "The endpoint to which to make remote-write requests.")
-	flag.Var(&opts.Labels, "labels", "The labels that should be applied to remote-write requests.")
-	flag.StringVar(&opts.Listen, "listen", ":8080", "The address on which internal server runs.")
-	flag.StringVar(&opts.Name, "name", "up", "The name of the metric to send in remote-write requests.")
-	flag.StringVar(&opts.Token, "token", "", "The bearer token to set in the authorization header on remote-write requests.")
-	flag.StringVar(&opts.Period, "period", "1m", "The time to wait between remote-write requests.")
-	flag.Parse()
-
-	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	logger = log.WithPrefix(logger, "ts", log.DefaultTimestampUTC)
-	logger = log.WithPrefix(logger, "caller", log.DefaultCaller)
-
-	endpoint, err := url.ParseRequestURI(opts.Endpoint)
+	err := json.Unmarshal(b, &v)
 	if err != nil {
-		level.Error(logger).Log("msg", "--endpoint is invalid", "err", err)
-		return
+		return err
 	}
-	period, err := time.ParseDuration(opts.Period)
+
+	switch v.Data.Type {
+	case model.ValScalar:
+		var sv model.Scalar
+		err = json.Unmarshal(v.Data.Result, &sv)
+		qr.v = &sv
+
+	case model.ValVector:
+		var vv model.Vector
+		err = json.Unmarshal(v.Data.Result, &vv)
+		qr.v = vv
+
+	case model.ValMatrix:
+		var mv model.Matrix
+		err = json.Unmarshal(v.Data.Result, &mv)
+		qr.v = mv
+
+	default:
+		err = fmt.Errorf("unexpected value type %q", v.Data.Type)
+	}
+
+	return err
+}
+
+type options struct {
+	LogLevel          level.Option
+	WriteEndpoint     *url.URL
+	ReadEndpoint      *url.URL
+	Labels            labelArg
+	Listen            string
+	Name              string
+	Token             string
+	Period            time.Duration
+	Duration          time.Duration
+	Latency           time.Duration
+	InitialQueryDelay time.Duration
+	SuccessThreshold  float64
+}
+
+type metrics struct {
+	remoteWriteRequests   *prometheus.CounterVec
+	queryResponses        *prometheus.CounterVec
+	metricValueDifference prometheus.Histogram
+}
+
+func main() {
+	l := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	l = log.WithPrefix(l, "ts", log.DefaultTimestampUTC)
+	l = log.WithPrefix(l, "caller", log.DefaultCaller)
+	l = log.WithPrefix(l, "name", "up")
+
+	opts, err := parseFlags()
 	if err != nil {
-		level.Error(logger).Log("msg", "--period is invalid", "err", err)
-		return
+		level.Error(l).Log("msg", "could not parse command line flags", "err", err)
+		os.Exit(1)
 	}
-	opts.Labels = append(opts.Labels, prompb.Label{
-		Name:  "__name__",
-		Value: opts.Name,
-	})
+
+	l = level.NewFilter(l, opts.LogLevel)
+	l = log.WithPrefix(l, "caller", log.DefaultCaller)
 
 	reg := prometheus.NewRegistry()
-	reg.MustRegister(
-		prometheus.NewGoCollector(),
-		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
-		remoteWriteRequests,
-	)
+	m := registerMetrics(reg)
 
 	var g run.Group
 	{
@@ -117,13 +161,15 @@ func main() {
 		g.Add(func() error {
 			signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 			<-sig
+			level.Info(l).Log("msg", "caught interrupt")
 			return nil
 		}, func(_ error) {
-			level.Info(logger).Log("msg", "caught interrrupt")
 			close(sig)
 		})
 	}
+	// Schedule HTTP server
 	{
+		logger := log.With(l, "component", "http")
 		router := http.NewServeMux()
 		router.Handle("/metrics", promhttp.InstrumentMetricHandler(reg, promhttp.HandlerFor(reg, promhttp.HandlerOpts{})))
 		router.HandleFunc("/debug/pprof/", pprof.Index)
@@ -146,82 +192,351 @@ func main() {
 			}
 		})
 	}
+
+	ctx := context.Background()
+
+	var cancel context.CancelFunc
+	if opts.Duration != 0 {
+		ctx, cancel = context.WithTimeout(ctx, opts.Duration)
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
+	}
+
 	{
-		t := time.NewTicker(period)
-		bg, cancel := context.WithCancel(context.Background())
 		g.Add(func() error {
-			level.Info(logger).Log("msg", "starting the remote-write client")
-			for {
-				select {
-				case <-t.C:
-					ctx, cancel := context.WithTimeout(bg, period)
-					if err := post(ctx, endpoint, opts.Token, generate(opts.Labels)); err != nil {
-						level.Error(logger).Log("msg", "failed to make request", "err", err)
-					}
-					cancel()
-				case <-bg.Done():
-					return nil
+			l := log.With(l, "component", "writer")
+			level.Info(l).Log("msg", "starting the writer")
+
+			return runPeriodically(ctx, opts, m.remoteWriteRequests, l, func(rCtx context.Context) {
+				if err := write(rCtx, opts.WriteEndpoint, opts.Token, generate(opts.Labels), l); err != nil {
+					m.remoteWriteRequests.WithLabelValues("error").Inc()
+					level.Error(l).Log("msg", "failed to make request", "err", err)
+				} else {
+					m.remoteWriteRequests.WithLabelValues("success").Inc()
 				}
-			}
+			})
 		}, func(_ error) {
-			t.Stop()
+			cancel()
+		})
+	}
+
+	if opts.ReadEndpoint != nil {
+		g.Add(func() error {
+			l := log.With(l, "component", "reader")
+			level.Info(l).Log("msg", "starting the reader")
+
+			// Wait for at least one period before start reading metrics.
+			level.Info(l).Log("msg", "waiting for initial delay before querying for metrics")
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(opts.InitialQueryDelay):
+			}
+
+			level.Info(l).Log("msg", "start querying for metrics")
+
+			return runPeriodically(ctx, opts, m.queryResponses, l, func(rCtx context.Context) {
+				if err := read(rCtx, opts.ReadEndpoint, opts.Labels, -1*opts.InitialQueryDelay, opts.Latency, m); err != nil {
+					m.queryResponses.WithLabelValues("error").Inc()
+					level.Error(l).Log("msg", "failed to query", "err", err)
+				} else {
+					m.queryResponses.WithLabelValues("success").Inc()
+				}
+			})
+		}, func(_ error) {
 			cancel()
 		})
 	}
 
 	if err := g.Run(); err != nil {
-		stdlog.Fatal(err)
+		level.Error(l).Log("msg", "run group exited with error", "err", err)
+		os.Exit(1)
+	}
+
+	level.Info(l).Log("msg", "up completed its mission!")
+}
+
+func runPeriodically(ctx context.Context, opts options, c *prometheus.CounterVec, l log.Logger, f func(rCtx context.Context)) error {
+	var (
+		t        = time.NewTicker(opts.Period)
+		deadline time.Time
+		rCtx     context.Context
+		rCancel  context.CancelFunc
+	)
+
+	for {
+		select {
+		case <-t.C:
+			// NOTICE: Do not propagate parent context to prevent cancellation of in-flight request.
+			// It will be cancelled after the deadline.
+			deadline = time.Now().Add(opts.Period)
+			rCtx, rCancel = context.WithDeadline(context.Background(), deadline)
+
+			// Will only get scheduled once per period and guaranteed to get cancelled after deadline.
+			go func() {
+				defer rCancel() // Make sure context gets cancelled even if execution panics.
+
+				f(rCtx)
+			}()
+		case <-ctx.Done():
+			t.Stop()
+
+			select {
+			// If it gets immediately cancelled, zero value of deadline won't cause a lock!
+			case <-time.After(time.Until(deadline)):
+				rCancel()
+			case <-rCtx.Done():
+			}
+
+			return reportResults(l, c, opts.SuccessThreshold)
+		}
 	}
 }
 
-func generate(labels []prompb.Label) *prompb.WriteRequest {
-	now := time.Now().UnixNano() / int64(time.Millisecond)
-	w := prompb.WriteRequest{
-		Timeseries: []prompb.TimeSeries{
-			{
-				Labels: labels,
-				Samples: []prompb.Sample{
-					{
-						Value:     float64(now),
-						Timestamp: now,
-					},
-				},
-			},
-		},
+func read(ctx context.Context, endpoint *url.URL, labels []prompb.Label, ago, latency time.Duration, m metrics) error {
+	client, err := promapi.NewClient(promapi.Config{Address: endpoint.String()})
+	if err != nil {
+		return err
 	}
-	return &w
+
+	labelSelectors := make([]string, len(labels))
+	for i, label := range labels {
+		labelSelectors[i] = fmt.Sprintf(`%s="%s"`, label.Name, label.Value)
+	}
+
+	query := fmt.Sprintf("{%s}", strings.Join(labelSelectors, ","))
+
+	q := endpoint.Query()
+	q.Set("query", query)
+
+	ts := time.Now().Add(ago)
+	if !ts.IsZero() {
+		q.Set("time", formatTime(ts))
+	}
+
+	_, body, _, err := promapi.DoGetFallback(client, ctx, endpoint, q) //nolint:bodyclose
+	if err != nil {
+		return errors.Wrap(err, "query request failed")
+	}
+
+	var result queryResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return errors.Wrap(err, "query response parse failed")
+	}
+
+	vec := result.v.(model.Vector)
+	if len(vec) != 1 {
+		return fmt.Errorf("expected one metric, got %d", len(vec))
+	}
+
+	t := time.Unix(int64(vec[0].Value/1000), 0)
+
+	diffSeconds := time.Since(t).Seconds()
+
+	m.metricValueDifference.Observe(diffSeconds)
+
+	if diffSeconds > latency.Seconds() {
+		return fmt.Errorf("metric value is too old: %2.fs", diffSeconds)
+	}
+
+	return nil
 }
 
-func post(ctx context.Context, endpoint *url.URL, token string, wreq *prompb.WriteRequest) error {
+func write(ctx context.Context, endpoint fmt.Stringer, token string, wreq proto.Message, l log.Logger) error {
 	var (
 		buf []byte
 		err error
 		req *http.Request
 		res *http.Response
 	)
-	defer func() {
-		if err != nil {
-			remoteWriteRequests.WithLabelValues("error").Inc()
-			return
-		}
-		remoteWriteRequests.WithLabelValues("success").Inc()
-	}()
+
 	buf, err = proto.Marshal(wreq)
 	if err != nil {
 		return errors.Wrap(err, "marshalling proto")
 	}
+
 	req, err = http.NewRequest("POST", endpoint.String(), bytes.NewBuffer(snappy.Encode(nil, buf)))
 	if err != nil {
 		return errors.Wrap(err, "creating request")
 	}
+
 	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req.WithContext(ctx))
+
+	res, err = http.DefaultClient.Do(req.WithContext(ctx)) //nolint:bodyclose
 	if err != nil {
 		return errors.Wrap(err, "making request")
 	}
+
+	defer exhaustCloseWithLogOnErr(l, res.Body)
+
 	if res.StatusCode != http.StatusOK {
 		err = errors.New(res.Status)
 		return errors.Wrap(err, "non-200 status")
 	}
+
 	return nil
+}
+
+func reportResults(l log.Logger, c *prometheus.CounterVec, threshold float64) error {
+	metrics := make(chan prometheus.Metric, 2)
+	c.Collect(metrics)
+	close(metrics)
+
+	var success, errors float64
+
+	for m := range metrics {
+		m1 := &dto.Metric{}
+		if err := m.Write(m1); err != nil {
+			level.Warn(l).Log("msg", "cannot read success and error count from prometheus counter", "err", err)
+		}
+
+		for _, l := range m1.Label {
+			switch *l.Value {
+			case "error":
+				errors = m1.GetCounter().GetValue()
+			case "success":
+				success = m1.GetCounter().GetValue()
+			}
+		}
+	}
+
+	level.Info(l).Log("msg", "number of requests", "success", success, "errors", errors)
+
+	ratio := success / (success + errors)
+	if ratio < threshold {
+		level.Error(l).Log("msg", "ratio is below threshold")
+		return fmt.Errorf("failed with less than %2.f%% success ratio - actual %2.f%%", threshold*100, ratio*100)
+	}
+
+	return nil
+}
+
+func generate(labels []prompb.Label) *prompb.WriteRequest {
+	timestamp := time.Now().UnixNano() / int64(time.Millisecond)
+
+	return &prompb.WriteRequest{
+		Timeseries: []prompb.TimeSeries{
+			{
+				Labels: labels,
+				Samples: []prompb.Sample{
+					{
+						Value:     float64(timestamp),
+						Timestamp: timestamp,
+					},
+				},
+			},
+		},
+	}
+}
+
+// Helpers
+
+func parseFlags() (options, error) {
+	var (
+		rawWriteEndpoint string
+		rawReadEndpoint  string
+		rawLogLevel      string
+	)
+
+	opts := options{}
+
+	flag.StringVar(&rawLogLevel, "log.level", "info", "The log filtering level. Options: 'error', 'warn', 'info', 'debug'.")
+	flag.StringVar(&rawWriteEndpoint, "endpoint-write", "", "The endpoint to which to make remote-write requests.")
+	flag.StringVar(&rawReadEndpoint, "endpoint-read", "", "The endpoint to which to make query requests.")
+	flag.Var(&opts.Labels, "labels", "The labels in addition to '__name__' that should be applied to remote-write requests.")
+	flag.StringVar(&opts.Listen, "listen", ":8080", "The address on which internal server runs.")
+	flag.StringVar(&opts.Name, "name", "up", "The name of the metric to send in remote-write requests.")
+	flag.StringVar(&opts.Token, "token", "", "The bearer token to set in the authorization header on remote-write requests.")
+	flag.DurationVar(&opts.Period, "period", 5*time.Second, "The time to wait between remote-write requests.")
+	flag.DurationVar(&opts.Duration, "duration", 5*time.Minute, "The duration of the up command to run until it stops.")
+	flag.Float64Var(&opts.SuccessThreshold, "threshold", 0.9, "The percentage of successful requests needed to succeed overall. 0 - 1.")
+	flag.DurationVar(&opts.Latency, "latency", 15*time.Second, "The maximum allowable latency between writing and reading.")
+	flag.DurationVar(&opts.InitialQueryDelay, "initial-query-delay", 5*time.Second, "The time to wait before executing the first query.")
+	flag.Parse()
+
+	switch rawLogLevel {
+	case "error":
+		opts.LogLevel = level.AllowError()
+	case "warn":
+		opts.LogLevel = level.AllowWarn()
+	case "info":
+		opts.LogLevel = level.AllowInfo()
+	case "debug":
+		opts.LogLevel = level.AllowDebug()
+	default:
+		panic("unexpected log level")
+	}
+
+	writeEndpoint, err := url.ParseRequestURI(rawWriteEndpoint)
+	if err != nil {
+		return opts, fmt.Errorf("--endpoint-write is invalid: %w", err)
+	}
+
+	opts.WriteEndpoint = writeEndpoint
+
+	var readEndpoint *url.URL
+	if rawReadEndpoint != "" {
+		readEndpoint, err = url.ParseRequestURI(rawReadEndpoint)
+		if err != nil {
+			return opts, fmt.Errorf("--endpoint-read is invalid: %w", err)
+		}
+	}
+
+	opts.ReadEndpoint = readEndpoint
+
+	if opts.Duration <= opts.Period {
+		return opts, errors.New("--duration cannot be less than period")
+	}
+
+	if opts.Latency <= opts.Period {
+		return opts, errors.New("--latency cannot be less than period")
+	}
+
+	opts.Labels = append(opts.Labels, prompb.Label{
+		Name:  "__name__",
+		Value: opts.Name,
+	})
+
+	return opts, err
+}
+
+func registerMetrics(reg *prometheus.Registry) metrics {
+	m := metrics{
+		remoteWriteRequests: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "up_remote_writes_total",
+			Help: "Total number of remote write requests.",
+		}, []string{"result"}),
+		queryResponses: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "up_queries_total",
+			Help: "The total number of queries made.",
+		}, []string{"result"}),
+		metricValueDifference: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "up_metric_value_difference",
+			Help:    "The time difference between the current timestamp and the timestamp in the metrics value.",
+			Buckets: prometheus.LinearBuckets(4, 0.25, 16),
+		}),
+	}
+	reg.MustRegister(
+		prometheus.NewGoCollector(),
+		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+		m.remoteWriteRequests,
+		m.queryResponses,
+		m.metricValueDifference,
+	)
+
+	return m
+}
+
+func exhaustCloseWithLogOnErr(l log.Logger, rc io.ReadCloser) {
+	if _, err := io.Copy(ioutil.Discard, rc); err != nil {
+		level.Warn(l).Log("msg", "failed to exhaust reader, performance may be impeded", "err", err)
+	}
+
+	if err := rc.Close(); err != nil {
+		level.Warn(l).Log("msg", "detected close error", "err", errors.Wrap(err, "response body close"))
+	}
+}
+
+func formatTime(t time.Time) string {
+	return strconv.FormatFloat(float64(t.Unix())+float64(t.Nanosecond())/1e9, 'f', -1, 64)
 }

--- a/vendor/github.com/prometheus/client_golang/api/client.go
+++ b/vendor/github.com/prometheus/client_golang/api/client.go
@@ -1,0 +1,156 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package api provides clients for the HTTP APIs.
+package api
+
+import (
+	"context"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+)
+
+type Warnings []string
+
+// DefaultRoundTripper is used if no RoundTripper is set in Config.
+var DefaultRoundTripper http.RoundTripper = &http.Transport{
+	Proxy: http.ProxyFromEnvironment,
+	DialContext: (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).DialContext,
+	TLSHandshakeTimeout: 10 * time.Second,
+}
+
+// Config defines configuration parameters for a new client.
+type Config struct {
+	// The address of the Prometheus to connect to.
+	Address string
+
+	// RoundTripper is used by the Client to drive HTTP requests. If not
+	// provided, DefaultRoundTripper will be used.
+	RoundTripper http.RoundTripper
+}
+
+func (cfg *Config) roundTripper() http.RoundTripper {
+	if cfg.RoundTripper == nil {
+		return DefaultRoundTripper
+	}
+	return cfg.RoundTripper
+}
+
+// Client is the interface for an API client.
+type Client interface {
+	URL(ep string, args map[string]string) *url.URL
+	Do(context.Context, *http.Request) (*http.Response, []byte, Warnings, error)
+}
+
+// DoGetFallback will attempt to do the request as-is, and on a 405 it will fallback to a GET request.
+func DoGetFallback(c Client, ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, error) {
+	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(args.Encode()))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, body, warnings, err := c.Do(ctx, req)
+	if resp != nil && resp.StatusCode == http.StatusMethodNotAllowed {
+		u.RawQuery = args.Encode()
+		req, err = http.NewRequest(http.MethodGet, u.String(), nil)
+		if err != nil {
+			return nil, nil, warnings, err
+		}
+
+	} else {
+		if err != nil {
+			return resp, body, warnings, err
+		}
+		return resp, body, warnings, nil
+	}
+	return c.Do(ctx, req)
+}
+
+// NewClient returns a new Client.
+//
+// It is safe to use the returned Client from multiple goroutines.
+func NewClient(cfg Config) (Client, error) {
+	u, err := url.Parse(cfg.Address)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+
+	return &httpClient{
+		endpoint: u,
+		client:   http.Client{Transport: cfg.roundTripper()},
+	}, nil
+}
+
+type httpClient struct {
+	endpoint *url.URL
+	client   http.Client
+}
+
+func (c *httpClient) URL(ep string, args map[string]string) *url.URL {
+	p := path.Join(c.endpoint.Path, ep)
+
+	for arg, val := range args {
+		arg = ":" + arg
+		p = strings.Replace(p, arg, val, -1)
+	}
+
+	u := *c.endpoint
+	u.Path = p
+
+	return &u
+}
+
+func (c *httpClient) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, Warnings, error) {
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+	resp, err := c.client.Do(req)
+	defer func() {
+		if resp != nil {
+			resp.Body.Close()
+		}
+	}()
+
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	var body []byte
+	done := make(chan struct{})
+	go func() {
+		body, err = ioutil.ReadAll(resp.Body)
+		close(done)
+	}()
+
+	select {
+	case <-ctx.Done():
+		<-done
+		err = resp.Body.Close()
+		if err == nil {
+			err = ctx.Err()
+		}
+	case <-done:
+	}
+
+	return resp, body, nil, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -289,7 +289,7 @@ github.com/mozillazg/go-cos
 github.com/mozillazg/go-httpheader
 # github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 github.com/mwitkow/go-conntrack
-# github.com/observatorium/up v0.0.0-20191211124247-2187e5c6701d
+# github.com/observatorium/up v0.0.0-20200109183502-89757a581729
 github.com/observatorium/up
 # github.com/oklog/run v1.0.0
 github.com/oklog/run
@@ -312,6 +312,7 @@ github.com/pmezard/go-difflib/difflib
 github.com/pquerna/cachecontrol
 github.com/pquerna/cachecontrol/cacheobject
 # github.com/prometheus/client_golang v1.2.1
+github.com/prometheus/client_golang/api
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promauto


### PR DESCRIPTION
This commit updates the telemter v2 integration test to use UP for the
querying functionality, rather than using a bash loop.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @kakkoyun 