### PR TITLE
jsonnet/telemeter: Add recording rule for cluster availability

### DIFF
--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -23,6 +23,12 @@
                 sort_desc(max by (_id,code) (code:apiserver_request_count:rate:sum{code=~"(4|5)\\d\\d"}) > 0.5)
               |||,
             },
+            {
+              record: 'id_version:cluster_available',
+              expr: |||
+                bottomk by (_id) (1, max by (_id, version) (0 * cluster_version{type="failure"}) or max by (_id, version) (1 + 0 * cluster_version{type="current"}))
+              |||,
+            },
           ],
         },
       ],


### PR DESCRIPTION
We have defined the OpenShift SLI based on whether the cluster
version operator is reporting a failure or not over a period of
time. To better support queries that attempt to aggregate availability
over classes of cluster, create a recording rule that is 1 when
a cluster is available and 0 when the cluster is reporting unhealthy.
If the cluster is not reporting any metrics it would have no data
at that point in time. Include the current version of the cluster
since it is implicit at the time of the recording rule.

This can be used in more complex aggregates by joining on cluster
id.