### PR TITLE
jsonnet/telemeter: Record a "subscribed cluster" metric

### DIFF
--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -23,6 +23,12 @@
                 sort_desc(max by (_id,code) (code:apiserver_request_count:rate:sum{code=~"(4|5)\\d\\d"}) > 0.5)
               |||,
             },
+            {
+              record: 'id_version:cluster_available',
+              expr: |||
+                bottomk by (_id) (1, max by (_id, version) (0 * cluster_version{type="failure"}) or max by (_id, version) (1 + 0 * cluster_version{type="current"}))
+              |||,
+            },
           ],
         },
       ],

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -29,6 +29,12 @@
                 bottomk by (_id) (1, max by (_id, version) (0 * cluster_version{type="failure"}) or max by (_id, version) (1 + 0 * cluster_version{type="current"}))
               |||,
             },
+            {
+              record: 'id_version_ebs_account_internal:cluster_subscribed',
+              expr: |||
+                topk by (_id) (1, max by (_id, managed, ebs_account, internal) (label_replace(label_replace((subscription_labels{support=~"Standard|Premium|Layered"} * 0 + 1) or subscription_labels * 0, "internal", "true", "email_domain", "redhat.com|(.*\\.|^)ibm.com"), "managed", "", "managed", "false")) + on(_id) group_left(version) (topk by (_id) (1, 0*cluster_version{type="current"})))
+              |||,
+            },
           ],
         },
       ],


### PR DESCRIPTION
There are a number of key dimensions joined against the subscription data
that almost all queries base on.

1. Is it subscribed 
2. Is it internal 
3. Is it openshift dedicated 
4. Is it in a range of versions
5. AND is it currently running (subscription_labels does not check that)

This recording rule collapses those into a single metric with cardinality
O(clusters) that should dramatically reduce the cost of queries.

Combined with the previous rule (available) the extremely common query
"which subscribed clusters are unhealthy" becomes

```
id_version:cluster_available == 0 + on(_id) max by (_id) (id_version_ebs_account_internal:cluster_subscribed == 1)
```

This also reduces the data that must be searched for almost all other joins
and some dashboards.

Question: how expensive is this recording rule?