### PR TITLE
pkg/receive: return correct status code

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -67,7 +67,8 @@ func (h *Handler) Receive(w http.ResponseWriter, r *http.Request) {
 	if resp.StatusCode/100 != 2 {
 		msg := "upstream response status is not 200 OK"
 		level.Error(h.logger).Log("msg", msg, "statuscode", resp.Status)
-		http.Error(w, msg, http.StatusBadGateway)
+		http.Error(w, msg, resp.StatusCode)
 		return
 	}
+	w.WriteHeader(resp.StatusCode)
 }


### PR DESCRIPTION
status code, i.e. it does not overwrite the status code returned by the
downstream handler.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @metalmatze @brancz @kakkoyun @bwplotka 