### PR TITLE
Fix remote write metrics

### DIFF
--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -468,7 +468,7 @@ func (o *Options) Run() error {
 	transforms.With(metricfamily.NewElide(o.ElideLabels...))
 
 	server := httpserver.New(o.Logger, store, validator, transforms, o.TTL)
-	receiver := receive.NewHandler(o.Logger, o.ForwardURL)
+	receiver := receive.NewHandler(o.Logger, o.ForwardURL, prometheus.DefaultRegisterer)
 
 	internalPathJSON, _ := json.MarshalIndent(Paths{Paths: internalPaths}, "", "  ")
 	externalPathJSON, _ := json.MarshalIndent(Paths{Paths: []string{"/", "/authorize", "/upload", "/healthz", "/healthz/ready", "/metrics/v1/receive"}}, "", "  ")

--- a/pkg/store/forward/forward.go
+++ b/pkg/store/forward/forward.go
@@ -26,21 +26,21 @@ const (
 
 var (
 	forwardSamples = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "telemeter_forward_samples_total",
-		Help: "Total amount of samples successfully forwarded",
+		Name: "telemeter_v1_forward_samples_total",
+		Help: "Total amount of successfully forwarded samples from v1 requests.",
 	})
 	forwardRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "telemeter_forward_requests_total",
-		Help: "Total amount of requests forwarded",
+		Name: "telemeter_v1_forward_requests_total",
+		Help: "Total amount of forwarded v1 requests.",
 	}, []string{"result"})
 	forwardDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "telemeter_forward_request_duration_seconds",
-		Help:    "Tracks the duration of all forwarding requests",
+		Name:    "telemeter_v1_forward_request_duration_seconds",
+		Help:    "Tracks the duration of all requests forwarded v1.",
 		Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5}, // max = timeout
 	}, []string{"status_code"})
 	overwrittenTimestamps = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "telemeter_forward_overwritten_timestamps_total",
-		Help: "Total number of timestamps that were overwritten",
+		Name: "telemeter_v1_forward_overwritten_timestamps_total",
+		Help: "Total number of timestamps from v1 requests that were overwritten.",
 	})
 )
 


### PR DESCRIPTION
Today, we only track the number of errors encountered when forwarding requests from the v1 upload endpoint to thanos. We don't track the total amount of requests made from the v1 upload endpoint handler. We also don't track any requests made when forwarding requests from the v2 endpoint to thanos.

This PR adds these metrics to give us better visibility during another incident.

cc @metalmatze @brancz @bwplotka @kakkoyun 