### PR TITLE
dockerfiles: simplify app-sre build tooling

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -2,24 +2,10 @@
 
 set -exv
 
-IMAGE_BUILD="telemeter-build"
-DOCKERFILE_BUILD="dockerfiles/Dockerfile.build"
-
 IMAGE="quay.io/app-sre/telemeter"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
-DOCKERFILE_DEPLOY="dockerfiles/Dockerfile.deploy"
 
-BINARIES="telemeter-client telemeter-server authorization-server"
-
-mkdir -p tmp
-
-docker build -f $DOCKERFILE_BUILD -t $IMAGE_BUILD .
-
-docker run --rm $IMAGE_BUILD \
-    tar -C /go/src/github.com/openshift/telemeter/ -cf - $BINARIES | \
-    tar -C tmp -xf -
-
-docker build -f $DOCKERFILE_DEPLOY -t "${IMAGE}:${IMAGE_TAG}" .
+docker build -t "${IMAGE}:${IMAGE_TAG}" .
 
 if [[ -n "$QUAY_USER" && -n "$QUAY_TOKEN" ]]; then
     DOCKER_CONF="$PWD/.docker"

--- a/dockerfiles/Dockerfile.build
+++ b/dockerfiles/Dockerfile.build
@@ -1,6 +1,0 @@
-FROM openshift/origin-release:golang-1.10
-COPY . /go/src/github.com/openshift/telemeter
-RUN cd /go/src/github.com/openshift/telemeter && \
-    go build ./cmd/telemeter-client && \
-    go build ./cmd/telemeter-server && \
-    go build ./cmd/authorization-server

--- a/dockerfiles/Dockerfile.deploy
+++ b/dockerfiles/Dockerfile.deploy
@@ -1,4 +1,0 @@
-FROM centos:7
-COPY tmp/telemeter-client /usr/bin/
-COPY tmp/telemeter-server /usr/bin/
-COPY tmp/authorization-server /usr/bin/

--- a/dockerfiles/README.txt
+++ b/dockerfiles/README.txt
@@ -1,3 +1,0 @@
-These Dockerfiles are used in the case that the `docker build` does not support
-multi-stage builds. By default it's recommended to use the multistage
-Dockerfile in the above directory.


### PR DESCRIPTION
This commit eliminates the dockerfiles directory at the root of the
repository and updates the build_deploy.sh script used by App-SRE
tooling to directly use the main Dockerfile.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @jfchevrette @jmelis @brancz 