### PR TITLE
Bug 1803106: Backport cam_app_workload_migrations metric to release-4.3

### DIFF
--- a/docs/data-collection.md
+++ b/docs/data-collection.md
@@ -162,6 +162,9 @@ For the OpenShift 4 Developer Preview we will be sending back these exact attrib
   // cluster:network_attachment_definition_enabled_instance_up  informs (1 or 0) if the cluster has
   //at least max of one instance with  k8s.v1.cni.cncf.io/networks annotation, labelled by networks (any or sriov).
   '{__name__="cluster:network_attachment_definition_enabled_instance_up:max"}',
+  // cam_app_workload_migrations tracks number of app workload migrations
+  // by current state. Tracked migration states are idle, running, completed, and failed.
+  '{__name__="cam_app_workload_migrations"}',
 ]
 ```
 

--- a/jsonnet/telemeter/metrics.jsonnet
+++ b/jsonnet/telemeter/metrics.jsonnet
@@ -154,4 +154,7 @@
   // cluster:network_attachment_definition_enabled_instance_up  informs (1 or 0) if the cluster has
   //at least max of one instance with  k8s.v1.cni.cncf.io/networks annotation, labelled by networks (any or sriov).
   '{__name__="cluster:network_attachment_definition_enabled_instance_up:max"}',
+  // cam_app_workload_migrations tracks number of app workload migrations
+  // by current state. Tracked migration states are idle, running, completed, and failed.
+  '{__name__="cam_app_workload_migrations"}',
 ]

--- a/manifests/benchmark/clusterRoleBindingPrometheusOperator.yaml
+++ b/manifests/benchmark/clusterRoleBindingPrometheusOperator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.34.0
+    app.kubernetes.io/version: v0.34.1
   name: telemeter-benchmark
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/benchmark/deploymentPrometheusOperator.yaml
+++ b/manifests/benchmark/deploymentPrometheusOperator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.34.0
+    app.kubernetes.io/version: v0.34.1
   name: prometheus-operator
   namespace: telemeter-benchmark
 spec:
@@ -18,15 +18,15 @@ spec:
       labels:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: prometheus-operator
-        app.kubernetes.io/version: v0.34.0
+        app.kubernetes.io/version: v0.34.1
     spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
         - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.34.0
-        image: quay.io/coreos/prometheus-operator:v0.34.0
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.34.1
+        image: quay.io/coreos/prometheus-operator:v0.34.1
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/manifests/benchmark/serviceAccountPrometheusOperator.yaml
+++ b/manifests/benchmark/serviceAccountPrometheusOperator.yaml
@@ -4,6 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.34.0
+    app.kubernetes.io/version: v0.34.1
   name: prometheus-operator
   namespace: telemeter-benchmark

--- a/manifests/benchmark/statefulSetTelemeterServer.yaml
+++ b/manifests/benchmark/statefulSetTelemeterServer.yaml
@@ -71,6 +71,7 @@ spec:
         - --whitelist={__name__="console_url"}
         - --whitelist={__name__="cluster:network_attachment_definition_instances:max"}
         - --whitelist={__name__="cluster:network_attachment_definition_enabled_instance_up:max"}
+        - --whitelist={__name__="cam_app_workload_migrations"}
         env:
         - name: NAME
           valueFrom:

--- a/manifests/client/deployment.yaml
+++ b/manifests/client/deployment.yaml
@@ -73,6 +73,7 @@ spec:
         - --match={__name__="console_url"}
         - --match={__name__="cluster:network_attachment_definition_instances:max"}
         - --match={__name__="cluster:network_attachment_definition_enabled_instance_up:max"}
+        - --match={__name__="cam_app_workload_migrations"}
         env:
         - name: ANONYMIZE_LABELS
           value: ""


### PR DESCRIPTION
Follow up to https://github.com/openshift/telemeter/pull/298, backport of `cam_app_workload_migrations` metric was requested by Clayton per https://github.com/openshift/telemeter/pull/298#issuecomment-577158997

