### PR TITLE
jsonnet: Add recording rule to precalculate non red hat, non ibm clusters

### DIFF
--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -35,6 +35,12 @@
                 topk by (_id) (1, max by (_id, managed, ebs_account, internal) (label_replace(label_replace((subscription_labels{support=~"Standard|Premium|Layered"} * 0 + 1) or subscription_labels * 0, "internal", "true", "email_domain", "redhat.com|(.*\\.|^)ibm.com"), "managed", "", "managed", "false")) + on(_id) group_left(version) (topk by (_id) (1, 0*cluster_version{type="current"})))
               |||,
             },
+            {
+              record: 'subscription_labels:not_redhat_not_ibm',
+              expr: |||
+                topk by (_id) (1, 0 *subscription_labels{email_domain!~"redhat.com|(^|.*\\.)ibm.com"})
+              |||,
+            },
           ],
         },
       ],

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -38,7 +38,24 @@
             {
               record: 'subscription_labels:not_redhat_not_ibm',
               expr: |||
-                topk by (_id) (1, 0 *subscription_labels{email_domain!~"redhat.com|(^|.*\\.)ibm.com"})
+                topk by (_id) (1, subscription_labels{email_domain!~"redhat.com|(^|.*\\.)ibm.com"})
+              |||,
+            },
+            {
+              record: 'subscription_labels:not_redhat_not_ibm:short_version',
+              expr: |||
+                (
+                  ((time() - topk by (_id) (1,
+                    label_replace(
+                      label_replace(cluster_version{type="current"}, "version", "4.$1-0.$2", "version", "4\\.(\\d+\\.\\d+)-0.(ci|nightly|okd).*"),
+                      "version",
+                      "ci-pull-requests",
+                      "version",
+                      "0.0.1-.*"
+                    )
+                  )))
+                  + on (_id) group_left() (0 * subscription_labels:not_redhat_not_ibm) + 0
+                ))
               |||,
             },
           ],


### PR DESCRIPTION
This recording rule will pre-calculate one of the more expensive parts of queries that we perform often in similar ways across a lot of queries.

@smarterclayton @metalmatze @s-urbaniak @lilic @bwplotka @squat 