### PR TITLE
jsonnet/benchmark: ensure benchmark has metrics

### DIFF
--- a/jsonnet/benchmark.jsonnet
+++ b/jsonnet/benchmark.jsonnet
@@ -1,5 +1,5 @@
-local t = (import 'telemeter/benchmark.libsonnet');
-
-{ [name + 'TelemeterServer']: t.telemeterServer[name] for name in std.objectFields(t.telemeterServer) } +
-{ [name + 'PrometheusOperator']: t.prometheusOperator[name] for name in std.objectFields(t.prometheusOperator) } +
-{ [name + 'Prometheus']: t.prometheus[name] for name in std.objectFields(t.prometheus) }
+function(metrics=[])
+  local t = (import 'telemeter/benchmark.libsonnet') { _config+: { telemeterServer+: { whitelist+: metrics } } };
+  { [name + 'TelemeterServer']: t.telemeterServer[name] for name in std.objectFields(t.telemeterServer) } +
+  { [name + 'PrometheusOperator']: t.prometheusOperator[name] for name in std.objectFields(t.prometheusOperator) } +
+  { [name + 'Prometheus']: t.prometheus[name] for name in std.objectFields(t.prometheus) }

--- a/jsonnet/telemeter/benchmark.libsonnet
+++ b/jsonnet/telemeter/benchmark.libsonnet
@@ -1,21 +1,19 @@
-// We have to import the entire Prometheus Operator dependency first
-// before selecting the fields we want so that the config overrides
-// the settings in the import.
-local b = (import 'prometheus-operator/prometheus-operator.libsonnet') +
-          (import 'benchmark/kubernetes.libsonnet') + {
+local config = {
   _config+:: {
     namespace: 'telemeter-benchmark',
-    telemeterServer+: {
-      whitelist+: [],
-    },
   },
 };
 
-{
+// We have to import the entire Prometheus Operator dependency first
+// before selecting the fields we want so that the config overrides
+// the settings in the import.
+local po = (import 'prometheus-operator/prometheus-operator.libsonnet') + config;
+
+(import 'benchmark/kubernetes.libsonnet') + config + {
   prometheusOperator+:: {
-    clusterRoleBinding: b.prometheusOperator.clusterRoleBinding { metadata+: { name: 'telemeter-benchmark' } },
-    serviceAccount: b.prometheusOperator.serviceAccount,
-    deployment: b.prometheusOperator.deployment {
+    clusterRoleBinding: po.prometheusOperator.clusterRoleBinding { metadata+: { name: 'telemeter-benchmark' } },
+    serviceAccount: po.prometheusOperator.serviceAccount,
+    deployment: po.prometheusOperator.deployment {
       spec+: {
         template+: {
           spec+: {
@@ -31,6 +29,4 @@ local b = (import 'prometheus-operator/prometheus-operator.libsonnet') +
       },
     },
   },
-  telemeterServer+:: b.telemeterServer,
-  prometheus+:: b.prometheus,
 }

--- a/manifests/benchmark/statefulSetTelemeterServer.yaml
+++ b/manifests/benchmark/statefulSetTelemeterServer.yaml
@@ -25,6 +25,56 @@ spec:
         - --listen-cluster=0.0.0.0:8082
         - --shared-key=/etc/pki/service/tls.key
         - --authorize=http://localhost:8083
+        - --whitelist={__name__=~"cluster:usage:.*"}
+        - --whitelist={__name__="count:up0"}
+        - --whitelist={__name__="count:up1"}
+        - --whitelist={__name__="cluster_version"}
+        - --whitelist={__name__="cluster_version_available_updates"}
+        - --whitelist={__name__="cluster_operator_up"}
+        - --whitelist={__name__="cluster_operator_conditions"}
+        - --whitelist={__name__="cluster_version_payload"}
+        - --whitelist={__name__="cluster_installer"}
+        - --whitelist={__name__="cluster_infrastructure_provider"}
+        - --whitelist={__name__="cluster_feature_set"}
+        - --whitelist={__name__="instance:etcd_object_counts:sum"}
+        - --whitelist={__name__="alerts",alertstate="firing"}
+        - --whitelist={__name__="code:apiserver_request_count:rate:sum"}
+        - --whitelist={__name__="cluster:capacity_cpu_cores:sum"}
+        - --whitelist={__name__="cluster:capacity_memory_bytes:sum"}
+        - --whitelist={__name__="cluster:cpu_usage_cores:sum"}
+        - --whitelist={__name__="cluster:memory_usage_bytes:sum"}
+        - --whitelist={__name__="openshift:cpu_usage_cores:sum"}
+        - --whitelist={__name__="openshift:memory_usage_bytes:sum"}
+        - --whitelist={__name__="workload:cpu_usage_cores:sum"}
+        - --whitelist={__name__="workload:memory_usage_bytes:sum"}
+        - --whitelist={__name__="cluster:virt_platform_nodes:sum"}
+        - --whitelist={__name__="cluster:node_instance_type_count:sum"}
+        - --whitelist={__name__="cnv:vmi_status_running:count"}
+        - --whitelist={__name__="node_role_os_version_machine:cpu_capacity_cores:sum"}
+        - --whitelist={__name__="node_role_os_version_machine:cpu_capacity_sockets:sum"}
+        - --whitelist={__name__="subscription_sync_total"}
+        - --whitelist={__name__="csv_succeeded"}
+        - --whitelist={__name__="csv_abnormal"}
+        - --whitelist={__name__="ceph_cluster_total_bytes"}
+        - --whitelist={__name__="ceph_cluster_total_used_raw_bytes"}
+        - --whitelist={__name__="ceph_health_status"}
+        - --whitelist={__name__="job:ceph_osd_metadata:count"}
+        - --whitelist={__name__="job:kube_pv:count"}
+        - --whitelist={__name__="job:ceph_pools_iops:total"}
+        - --whitelist={__name__="job:ceph_pools_iops_bytes:total"}
+        - --whitelist={__name__="job:ceph_versions_running:count"}
+        - --whitelist={__name__="job:noobaa_total_unhealthy_buckets:sum"}
+        - --whitelist={__name__="job:noobaa_bucket_count:sum"}
+        - --whitelist={__name__="job:noobaa_total_object_count:sum"}
+        - --whitelist={__name__="noobaa_accounts_num"}
+        - --whitelist={__name__="noobaa_total_usage"}
+        - --whitelist={__name__="console_url"}
+        - --whitelist={__name__="cluster:network_attachment_definition_instances:max"}
+        - --whitelist={__name__="cluster:network_attachment_definition_enabled_instance_up:max"}
+        - --whitelist={__name__="insightsclient_request_send_total"}
+        - --whitelist={__name__="cam_app_workload_migrations"}
+        - --whitelist={__name__="cluster:apiserver_current_inflight_requests:sum:max_over_time:2m"}
+        - --whitelist={__name__="cluster:telemetry_selected_series:count"}
         env:
         - name: NAME
           valueFrom:


### PR DESCRIPTION
The metrics list was accidentally removed from the benchmark manifests in
a previous commit. This caused all benchmark tests to run without
telemeter-server accepting any metrics from the client, causing zero
load on the backend.

This commit reintroduces the metrics into the benchmarking manifests
using a jsonnet top-level-function.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @brancz @metalmatze 