### PR TITLE
jsonnet: remove prometheus operator

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -23,17 +23,6 @@
       "sum": "kyza6itqcvQHoKeJqsFjFQuMpj8RZsudC5/2vVxw5R0="
     },
     {
-      "name": "prometheus-operator",
-      "source": {
-        "git": {
-          "remote": "https://github.com/coreos/prometheus-operator",
-          "subdir": "jsonnet/prometheus-operator"
-        }
-      },
-      "version": "8d44e0990230144177f97cf62ae4f43b1c4e3168",
-      "sum": "5U7/8MD3pF9O0YDTtUhg4vctkUBRVFxZxWUyhtNiBM8="
-    },
-    {
       "name": "telemeter",
       "source": {
         "local": {

--- a/jsonnet/telemeter/jsonnetfile.json
+++ b/jsonnet/telemeter/jsonnetfile.json
@@ -9,16 +9,6 @@
                 }
             },
             "version": "master"
-        },
-        {
-            "name": "prometheus-operator",
-            "source": {
-                "git": {
-                    "remote": "https://github.com/coreos/prometheus-operator",
-                    "subdir": "jsonnet/prometheus-operator"
-                }
-            },
-            "version": "release-0.34"
         }
     ]
 }


### PR DESCRIPTION
This commit removes the prometheus operator jsonnet dependency, as this
is no longer needed.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @brancz 