### PR TITLE
Bug 1812719: jsonnet/telemeter: set cpu requests, unset limits

### DIFF
--- a/jsonnet/telemeter/client/kubernetes.libsonnet
+++ b/jsonnet/telemeter/client/kubernetes.libsonnet
@@ -128,7 +128,8 @@ local securePort = 8443;
         ] + matchRules) +
         container.withPorts(containerPort.newNamed('http', insecurePort)) +
         container.withVolumeMounts([sccabMount, secretMount]) +
-        container.withEnv([anonymize, from, id, to, httpProxy, httpsProxy, noProxy]);
+        container.withEnv([anonymize, from, id, to, httpProxy, httpsProxy, noProxy]) +
+        container.mixin.resources.withRequests({ cpu: '1m' });
 
       local reload =
         container.new('reload', $._config.imageRepos.configmapReload + ':' + $._config.versions.configmapReload) +
@@ -136,7 +137,8 @@ local securePort = 8443;
           '--webhook-url=http://localhost:%s/-/reload' % insecurePort,
           '--volume-dir=' + servingCertsCABundleMountPath,
         ]) +
-        container.withVolumeMounts([sccabMount]);
+        container.withVolumeMounts([sccabMount]) +
+        container.mixin.resources.withRequests({ cpu: '1m' });
 
       local proxy =
         container.new('kube-rbac-proxy', $._config.imageRepos.kubeRbacProxy + ':' + $._config.versions.kubeRbacProxy) +
@@ -149,8 +151,7 @@ local securePort = 8443;
           '--tls-cipher-suites=' + std.join(',', $._config.tlsCipherSuites),
         ] else []) +
         container.withPorts(containerPort.new(securePort) + containerPort.withName('https')) +
-        container.mixin.resources.withRequests({ cpu: '10m', memory: '20Mi' }) +
-        container.mixin.resources.withLimits({ cpu: '20m', memory: '40Mi' }) +
+        container.mixin.resources.withRequests({ cpu: '1m', memory: '20Mi' }) +
         container.withVolumeMounts([tlsMount]);
 
 

--- a/manifests/client/deployment.yaml
+++ b/manifests/client/deployment.yaml
@@ -47,6 +47,9 @@ spec:
         ports:
         - containerPort: 8080
           name: http
+        resources:
+          requests:
+            cpu: 1m
         volumeMounts:
         - mountPath: /etc/serving-certs-ca-bundle
           name: serving-certs-ca-bundle
@@ -59,6 +62,9 @@ spec:
         - --volume-dir=/etc/serving-certs-ca-bundle
         image: quay.io/openshift/origin-configmap-reload:v3.11
         name: reload
+        resources:
+          requests:
+            cpu: 1m
         volumeMounts:
         - mountPath: /etc/serving-certs-ca-bundle
           name: serving-certs-ca-bundle
@@ -74,11 +80,8 @@ spec:
         - containerPort: 8443
           name: https
         resources:
-          limits:
-            cpu: 20m
-            memory: 40Mi
           requests:
-            cpu: 10m
+            cpu: 1m
             memory: 20Mi
         volumeMounts:
         - mountPath: /etc/tls/private


### PR DESCRIPTION
This sets CPU requests to what I measured during an e2e run.
At the same time it unsets limits as this was recommended for OpenShift workloads.