### PR TITLE
Evaluate Telemeter rules only every minute

### DIFF
--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -4,6 +4,7 @@
       groups+: [
         {
           name: 'telemeter.rules',
+          interval: '1m',
           rules: [
             {
               record: 'name_reason:cluster_operator_degraded:count',


### PR DESCRIPTION
By default these rules get evaluated every 30s and right now we need ~40s  to evaluate them.
Every 60s should be plenty in normal circumstances.

/cc @squat @bwplotka 