### PR TITLE
Create a request logger per middleware / handler

### DIFF
--- a/pkg/server/ratelimited.go
+++ b/pkg/server/ratelimited.go
@@ -27,18 +27,18 @@ func Ratelimit(logger log.Logger, limit time.Duration, now func() time.Time, nex
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		logger = log.With(logger, "request", middleware.GetReqID(r.Context()))
+		rlogger := log.With(logger, "request", middleware.GetReqID(r.Context()))
 
 		clusterID, ok := ClusterIDFromContext(r.Context())
 		if !ok {
 			msg := "failed to get cluster ID from request"
-			level.Warn(logger).Log("msg", msg)
+			level.Warn(rlogger).Log("msg", msg)
 			http.Error(w, msg, http.StatusInternalServerError)
 			return
 		}
 
 		if err := s.limit(limit, now(), clusterID); err != nil {
-			level.Debug(logger).Log("msg", "rate limited", "err", err)
+			level.Debug(rlogger).Log("msg", "rate limited", "err", err)
 			http.Error(w, err.Error(), http.StatusTooManyRequests)
 			return
 		}


### PR DESCRIPTION
For every middleware or handler we create a new logger and get the request ID from the request.Context. However, adding a new key-value-pair to the logger per request, we need a new request logger instance. That why we now have `rlogger` to create the request logger.

/cc @brancz @kakkoyun @squat 