### PR TITLE
telemeter-server: Make downstream tenant ID configurable

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -29,6 +29,7 @@ type ClusterAuthorizer interface {
 // Handler knows the forwardURL for all requests
 type Handler struct {
 	ForwardURL string
+	tenantID   string
 	client     *http.Client
 	logger     log.Logger
 
@@ -37,9 +38,10 @@ type Handler struct {
 }
 
 // NewHandler returns a new Handler with a http client
-func NewHandler(logger log.Logger, forwardURL string, reg prometheus.Registerer) *Handler {
+func NewHandler(logger log.Logger, forwardURL string, reg prometheus.Registerer, tenantID string) *Handler {
 	h := &Handler{
 		ForwardURL: forwardURL,
+		tenantID:   tenantID,
 		client: &http.Client{
 			Timeout: forwardTimeout,
 		},
@@ -77,7 +79,7 @@ func (h *Handler) Receive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	req = req.WithContext(ctx)
-	req.Header.Add("THANOS-TENANT", "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43")
+	req.Header.Add("THANOS-TENANT", h.tenantID)
 
 	resp, err := h.client.Do(req)
 	if err != nil {

--- a/pkg/server/forward.go
+++ b/pkg/server/forward.go
@@ -56,7 +56,7 @@ func init() {
 
 // ForwardHandler gets a request containing metric families and
 // converts it to a remote write request forwarding it to the upstream at fowardURL.
-func ForwardHandler(logger log.Logger, forwardURL *url.URL) http.HandlerFunc {
+func ForwardHandler(logger log.Logger, forwardURL *url.URL, tenantID string) http.HandlerFunc {
 	client := http.Client{}
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -122,7 +122,7 @@ func ForwardHandler(logger log.Logger, forwardURL *url.URL) http.HandlerFunc {
 			http.Error(w, msg, http.StatusInternalServerError)
 			return
 		}
-		req.Header.Add("THANOS-TENANT", "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43")
+		req.Header.Add("THANOS-TENANT", tenantID)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/test/e2e/forward_test.go
+++ b/test/e2e/forward_test.go
@@ -81,7 +81,7 @@ func TestForward(t *testing.T) {
 					server.Ratelimit(log.NewNopLogger(), 4*time.Minute+30*time.Second, time.Now,
 						server.Snappy(
 							server.Validate(log.NewNopLogger(), metricfamily.MultiTransformer{}, 10*365*24*time.Hour, 500*1024, time.Now,
-								server.ForwardHandler(logger, receiveURL),
+								server.ForwardHandler(logger, receiveURL, "default-tenant"),
 							),
 						),
 					),

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -82,7 +82,7 @@ func TestReceiveValidateLabels(t *testing.T) {
 
 	var telemeterServer *httptest.Server
 	{
-		receiver := receive.NewHandler(log.NewNopLogger(), receiveServer.URL, prometheus.NewRegistry())
+		receiver := receive.NewHandler(log.NewNopLogger(), receiveServer.URL, prometheus.NewRegistry(), "default-tenant")
 
 		telemeterServer = httptest.NewServer(
 			fakeAuthorizeHandler(
@@ -132,7 +132,7 @@ func TestLimitBodySize(t *testing.T) {
 
 	var telemeterServer *httptest.Server
 	{
-		receiver := receive.NewHandler(log.NewNopLogger(), receiveServer.URL, prometheus.NewRegistry())
+		receiver := receive.NewHandler(log.NewNopLogger(), receiveServer.URL, prometheus.NewRegistry(), "default-tenant")
 
 		telemeterServer = httptest.NewServer(
 			fakeAuthorizeHandler(


### PR DESCRIPTION
Follow up from #332 

@squat @metalmatze @kakkoyun @krasi-georgiev @bwplotka 