### PR TITLE
Don't wrap forwardClient's transport with additional roundtrippers

### DIFF
--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -218,7 +218,7 @@ func (o *Options) Run() error {
 	}
 
 	var transport http.RoundTripper = &http.Transport{
-		Dial:                (&net.Dialer{Timeout: 10 * time.Second}).Dial,
+		DialContext:         (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
 		MaxIdleConnsPerHost: 10,
 		IdleConnTimeout:     30 * time.Second,
 	}
@@ -244,9 +244,11 @@ func (o *Options) Run() error {
 		}
 	}
 
-	forwardClient := http.Client{
+	forwardClient := &http.Client{
 		Timeout:   5 * time.Second,
-		Transport: telemeter_http.NewInstrumentedRoundTripper("forward", transport),
+		Transport: transport,
+		// TODO: Uncomment if it turns out there's no memory leak here
+		//Transport: telemeter_http.NewInstrumentedRoundTripper("forward", transport),
 	}
 
 	if o.OIDCIssuer != "" {
@@ -272,10 +274,11 @@ func (o *Options) Run() error {
 			Base:   authorizeClient.Transport,
 			Source: cfg.TokenSource(ctx),
 		}
-		forwardClient.Transport = &oauth2.Transport{
-			Base:   forwardClient.Transport,
-			Source: cfg.TokenSource(ctx),
-		}
+		// TODO: Uncomment if it turns out there's no memory leak here
+		//forwardClient.Transport = &oauth2.Transport{
+		//	Base:   forwardClient.Transport,
+		//	Source: cfg.TokenSource(ctx),
+		//}
 	}
 
 	switch {

--- a/pkg/server/forward.go
+++ b/pkg/server/forward.go
@@ -56,7 +56,7 @@ func init() {
 
 // ForwardHandler gets a request containing metric families and
 // converts it to a remote write request forwarding it to the upstream at fowardURL.
-func ForwardHandler(logger log.Logger, forwardURL *url.URL, tenantID string, client http.Client) http.HandlerFunc {
+func ForwardHandler(logger log.Logger, forwardURL *url.URL, tenantID string, client *http.Client) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		rlogger := log.With(logger, "request", middleware.GetReqID(r.Context()))
 

--- a/test/e2e/forward_test.go
+++ b/test/e2e/forward_test.go
@@ -81,7 +81,7 @@ func TestForward(t *testing.T) {
 					server.Ratelimit(log.NewNopLogger(), 4*time.Minute+30*time.Second, time.Now,
 						server.Snappy(
 							server.Validate(log.NewNopLogger(), metricfamily.MultiTransformer{}, 10*365*24*time.Hour, 500*1024, time.Now,
-								server.ForwardHandler(logger, receiveURL, "default-tenant", http.Client{}),
+								server.ForwardHandler(logger, receiveURL, "default-tenant", &http.Client{}),
 							),
 						),
 					),


### PR DESCRIPTION
Somewhere in here is probably a leak and I can only really reproduce on
our production system, so here we go.
If these are fine, then we can re-enable one by one until we fine out
which one is responsible.

/cc @squat 