### PR TITLE
Bug 1867510: fix CVP issues due to incorrect labels set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,12 @@ RUN cd /go/src/github.com/openshift/telemeter && \
     go build ./cmd/authorization-server
 
 FROM registry.svc.ci.openshift.org/ocp/4.6:base
+LABEL io.k8s.display-name="OpenShift Telemeter" \
+      io.k8s.description="" \
+      io.openshift.tags="openshift,monitoring" \
+      summary="" \
+      maintainer="OpenShift Monitoring Team <team-monitoring@redhat.com>"
+
 COPY --from=0 /go/src/github.com/openshift/telemeter/telemeter-client /usr/bin/
 COPY --from=0 /go/src/github.com/openshift/telemeter/telemeter-server /usr/bin/
 COPY --from=0 /go/src/github.com/openshift/telemeter/authorization-server /usr/bin/


### PR DESCRIPTION
- Fixing maintainer label to end with @redhat.com as this is expected
- Overriding summary label as it is inherited from base image and results with an incorrect value
- ~explicit golang 1.14 usage~
- ~explicit usage of openshift base image (as it is used in OSBS)~

/cc @openshift/openshift-team-monitoring
