### PR TITLE
Bug 1874112: Do not overwrite 3xx and 4xx from Tollbooth to 500

### DIFF
--- a/pkg/authorize/handler.go
+++ b/pkg/authorize/handler.go
@@ -112,7 +112,7 @@ func AgainstEndpoint(logger log.Logger, client *http.Client, endpoint *url.URL, 
 		return body, nil
 	default:
 		level.Warn(logger).Log("msg", "upstream server rejected request", "cluster", cluster, "body", string(body))
-		return body, NewErrorWithCode(fmt.Errorf("upstream rejected request with code %d", res.StatusCode), http.StatusInternalServerError)
+		return body, NewErrorWithCode(fmt.Errorf("upstream rejected request with code %d", res.StatusCode), res.StatusCode)
 	}
 }
 


### PR DESCRIPTION
We really want to propagate the status codes we got from Tollbooth, so we don't alert on too many 5xx if we get 4xx from Tollbooth...
