### PR TITLE
Bug 1877816: Provide synthetic recording rules for common cluster id -> key dimensional joins

### DIFF
--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -36,6 +36,12 @@
                 topk by (_id) (1, max by (_id, managed, ebs_account, internal) (label_replace(label_replace((subscription_labels{support=~"Standard|Premium|Layered"} * 0 + 1) or subscription_labels * 0, "internal", "true", "email_domain", "redhat.com|(.*\\.|^)ibm.com"), "managed", "", "managed", "false")) + on(_id) group_left(version) (topk by (_id) (1, 0*cluster_version{type="current"})))
               |||,
             },
+            {
+              record: 'id_primary_host_type',
+              expr: |||
+                0 * (max by (_id,host_type) (topk by (_id) (1, label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(cluster:virt_platform_nodes:sum, "host_type", "$1", "type", "(aws|ibm_.*|ovirt|none|rhev|gcp|openstack|hyperv|vmware)"), "host_type", "virt-unknown", "host_type", ""), "host_type", "kvm-unknown", "type", "kvm"), "host_type", "xen-unknown", "type", "xen.*"), "host_type", "metal", "host_type", "none"), "host_type", "ibm-$1", "host_type", "ibm[_-](power|systemz).*"))) or on(_id) label_replace(max by (_id) (cluster_version{type="current"}), "host_type", "", "host_type", ""))
+              |||,
+            },
           ],
         },
       ],

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -33,7 +33,7 @@
             {
               record: 'id_version_ebs_account_internal:cluster_subscribed',
               expr: |||
-                topk by (_id) (1, max by (_id, managed, ebs_account, internal) (label_replace(label_replace((subscription_labels{support=~"Standard|Premium|Layered"} * 0 + 1) or subscription_labels * 0, "internal", "true", "email_domain", "redhat.com|(.*\\.|^)ibm.com"), "managed", "", "managed", "false")) + on(_id) group_left(version) (topk by (_id) (1, 0*cluster_version{type="current"})))
+                topk by (_id) (1, max by (_id, managed, ebs_account, internal) (label_replace(label_replace((subscription_labels{support=~"Standard|Premium|Layered"} * 0 + 1) or subscription_labels * 0, "internal", "true", "email_domain", "redhat.com|(.*\\.|^)ibm.com"), "managed", "", "managed", "false")) + on(_id) group_left(version) (id_version*0) + on(_id) group_left(install_type) (id_install_type*0) + on(_id) group_left(primary_host_type) (id_primary_host_type*0) + on(_id) group_left(provider) (provider*0))
               |||,
             },
             {

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -48,6 +48,12 @@
                 0 * topk by (_id) (1, count by (_id, provider) (label_replace(cluster_infrastructure_provider * 0 + 2, "provider", "$1", "type", "(.*)")) or on(_id) label_replace(max by (_id) (cluster_version{type="current"}*0+1), "provider", "", "provider", "") or on(_id) label_replace(max by (_id) (cluster:node_instance_type_count:sum*0), "provider", "hypershift-unknown", "provider", ""))
               |||,
             },
+            {
+              record: 'id_version',
+              expr: |||
+                0 * (max by (_id,version) (cluster_version{type="current"}) or on(_id) label_replace(max by (_id) (cluster:node_instance_type_count:sum*0), "version", "", "unknown", ""))
+              |||,
+            },
           ],
         },
       ],

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -42,6 +42,12 @@
                 0 * (max by (_id,host_type) (topk by (_id) (1, label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(cluster:virt_platform_nodes:sum, "host_type", "$1", "type", "(aws|ibm_.*|ovirt|none|rhev|gcp|openstack|hyperv|vmware)"), "host_type", "virt-unknown", "host_type", ""), "host_type", "kvm-unknown", "type", "kvm"), "host_type", "xen-unknown", "type", "xen.*"), "host_type", "metal", "host_type", "none"), "host_type", "ibm-$1", "host_type", "ibm[_-](power|systemz).*"))) or on(_id) label_replace(max by (_id) (cluster_version{type="current"}), "host_type", "", "host_type", ""))
               |||,
             },
+            {
+              record: 'id_provider',
+              expr: |||
+                0 * topk by (_id) (1, count by (_id, provider) (label_replace(cluster_infrastructure_provider * 0 + 2, "provider", "$1", "type", "(.*)")) or on(_id) label_replace(max by (_id) (cluster_version{type="current"}*0+1), "provider", "", "provider", "") or on(_id) label_replace(max by (_id) (cluster:node_instance_type_count:sum*0), "provider", "hypershift-unknown", "provider", ""))
+              |||,
+            },
           ],
         },
       ],

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -54,6 +54,12 @@
                 0 * (max by (_id,version) (cluster_version{type="current"}) or on(_id) label_replace(max by (_id) (cluster:node_instance_type_count:sum*0), "version", "", "unknown", ""))
               |||,
             },
+            {
+              record: 'id_install_type',
+              expr: |||
+                0 * (count by (_id, install_type) (label_replace(label_replace(label_replace(label_replace(cluster_installer, "install_type", "upi", "type", "other"), "install_type", "ipi", "type", "openshift-install"), "install_type", "hive", "invoker", "hive"), "install_type", "assisted-installer", "invoker", "assisted-installer")) or on(_id) (label_replace(count by (_id) (cluster:virt_platform_nodes:sum), "install_type", "hypershift-unknown", "install_type", ""))*0)
+              |||,
+            },
           ],
         },
       ],


### PR DESCRIPTION
In order to make estimation of cluster distribution easier, synthesize the following recording rules that remove the need for complex joins in other queries by _id:

* `version` - the current version of the cluster or empty string if the cluster did not report the metric
* `host_type` - an enumeration representing the most common types of hardware within a cluster by node count - metal, known virt types, cloud types (which may cover hardware)
* `provider` - an enumeration representing the cloud provider type when known
* `install_type` - an enumeration representing how the cluster was installed

Each of these attempt to classify all clusters reporting to telemetry:

* Clusters older than the metrics that started reporting these values
* Clusters with topologies that are missing subsets of metrics (hypershift clusters are not reporting control plane metrics)
* Clusters with different interpretation of these values over different releases

This also changes the `cluster_subscribed` metric to include these new dimensions to improve dimensionality reduction queries (show me upi aws clusters on version 4.4 that are subscribed)