### PR TITLE
jsonnet/telemeter: Record which cloudpak a cluster appears to be

### DIFF
--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -60,6 +60,12 @@
                 0 * (count by (_id, install_type) (label_replace(label_replace(label_replace(label_replace(topk by (_id) (1, cluster_installer), "install_type", "upi", "type", "other"), "install_type", "ipi", "type", "openshift-install"), "install_type", "hive", "invoker", "hive"), "install_type", "assisted-installer", "invoker", "assisted-installer")) or on(_id) (label_replace(count by (_id) (cluster:virt_platform_nodes:sum), "install_type", "hypershift-unknown", "install_type", ""))*0)
               |||,
             },
+            {
+              record: 'id_cloudpak_type',
+              expr: |||
+                0 * (max by (_id,cloudpak_type) (topk by (_id) (1, count by (_id,cloudpak_type) (label_replace(subscription_sync_total{installed=~"ibm-((licensing|common-service)-operator).*"}, "cloudpak_type", "unknown", "", ".*")))))
+              |||,
+            }
           ],
         },
       ],


### PR DESCRIPTION
All known cloudpaks install at least one of the 'ibm-common-service'
operator or the 'ibm-licensing-operator'. To better track the known
cloudpaks report a metric that encodes the cloudpak_type of a cluster.
For now the only value reported is `unknown` to leave room to detect
type in the future.

A subsequent change will add this to the summary recording rule.