### PR TITLE
Makefile: enable jsonnetfmt check

### DIFF
--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -66,7 +66,7 @@
                 0 * (max by (_id,cloudpak_type) (topk by (_id) (1, count by (_id,cloudpak_type) (label_replace(subscription_sync_total{installed=~"ibm-((licensing|common-service)-operator).*"}, "cloudpak_type", "unknown", "", ".*")))))
               |||,
             },
-            {,
+            {
               // Identifies ebs_accounts into account_type by their likely status - Partner, Evaluation, Customer, or Internal. Sets the internal
               // label on any redhat.com or .ibm.com email domain. The account_type="Internal" selector should be preferred over internal="true"
               // since ibm.com accounts may be customers or running clusters on customer's behalf. account_type is mostly determined by whether

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/brancz/gojsontoyaml"
 	_ "github.com/campoy/embedmd"
 	_ "github.com/google/go-jsonnet/cmd/jsonnet"
+	_ "github.com/google/go-jsonnet/cmd/jsonnetfmt"
 	_ "github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb"
 	_ "github.com/observatorium/up"
 	_ "github.com/thanos-io/thanos/cmd/thanos"


### PR DESCRIPTION
This commit adds a Makefile target to format all jsonnet code. It also
removes "shellcheck" from the "format" target, as it is a linting tool,
not a formatter.

Includes fix from #364

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>