### PR TITLE
Bug 1905330: jsonnet: add memory requests to client containers

### DIFF
--- a/jsonnet/telemeter/client/kubernetes.libsonnet
+++ b/jsonnet/telemeter/client/kubernetes.libsonnet
@@ -129,7 +129,7 @@ local securePort = 8443;
         container.withPorts(containerPort.newNamed(insecurePort, 'http')) +
         container.withVolumeMounts([sccabMount, secretMount]) +
         container.withEnv([anonymize, from, id, to, httpProxy, httpsProxy, noProxy]) +
-        container.mixin.resources.withRequests({ cpu: '1m' });
+        container.mixin.resources.withRequests({ cpu: '1m', memory: '40Mi' });
 
       local reload =
         container.new('reload', $._config.imageRepos.configmapReload + ':' + $._config.versions.configmapReload) +
@@ -138,7 +138,7 @@ local securePort = 8443;
           '--volume-dir=' + servingCertsCABundleMountPath,
         ]) +
         container.withVolumeMounts([sccabMount]) +
-        container.mixin.resources.withRequests({ cpu: '1m' });
+        container.mixin.resources.withRequests({ cpu: '1m', memory: '10Mi' });
 
       local proxy =
         container.new('kube-rbac-proxy', $._config.imageRepos.kubeRbacProxy + ':' + $._config.versions.kubeRbacProxy) +

--- a/manifests/client/deployment.yaml
+++ b/manifests/client/deployment.yaml
@@ -50,6 +50,7 @@ spec:
         resources:
           requests:
             cpu: 1m
+            memory: 40Mi
         volumeMounts:
         - mountPath: /etc/serving-certs-ca-bundle
           name: serving-certs-ca-bundle
@@ -65,6 +66,7 @@ spec:
         resources:
           requests:
             cpu: 1m
+            memory: 10Mi
         volumeMounts:
         - mountPath: /etc/serving-certs-ca-bundle
           name: serving-certs-ca-bundle


### PR DESCRIPTION
As reported in https://bugzilla.redhat.com/show_bug.cgi?id=1905330 we must set the memory requests of the `telemeter-client` and `reload` containers before https://github.com/openshift/origin/pull/25747 lands.

/cc @openshift/openshift-team-monitoring 