### PR TITLE
remove AppSRE from owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,19 +6,10 @@ reviewers:
 - squat
 - s-urbaniak
 - smarterclayton
-- aditya-konarde
-- jfchevrette
-- jmelis
-- maorfr
-- pbergene
-- skryzhny
 - metalmatze
 - lilic
 - kakkoyun
-- rrati
 - bwplotka
-- rporres
-- arilivigni
 
 approvers:
 - brancz
@@ -26,16 +17,7 @@ approvers:
 - squat
 - s-urbaniak
 - smarterclayton
-- aditya-konarde
-- jfchevrette
-- jmelis
-- maorfr
-- pbergene
-- skryzhny
 - metalmatze
 - lilic
 - kakkoyun
-- rrati
 - bwplotka
-- rporres
-- arilivigni


### PR DESCRIPTION
When things started out and we had just a few services to run, it made sense that we attempt to be approvers on each of the repositories.
As we manage dozens of services with hundreds of repos, this approach no longer scales and we had decided to not proceed with it. Here is the MR to our onboarding docs which removes this section: https://gitlab.cee.redhat.com/service/app-interface/-/commit/5dd6d564a822ee05eedb7622ea672ea6cc37ebf7

As such, I am submitting this PR to remove all of AppSRE from being approvers.