### PR TITLE
add app.kubernetes.io/part-of label to telemeter client

### DIFF
--- a/jsonnet/telemeter/client.libsonnet
+++ b/jsonnet/telemeter/client.libsonnet
@@ -6,5 +6,9 @@
     telemeterClient+: {
       matchRules+: [],
     },
+    commonLabels+:: {
+      'app.kubernetes.io/component': 'telemetry-metrics-collector',
+      'app.kubernetes.io/name': 'telemeter-client',
+    },
   },
 }

--- a/jsonnet/telemeter/client/kubernetes.libsonnet
+++ b/jsonnet/telemeter/client/kubernetes.libsonnet
@@ -92,7 +92,7 @@ local securePort = 8443;
       local containerVolumeMount = container.volumeMountsType;
       local containerEnv = container.envType;
 
-      local podLabels = { 'k8s-app': 'telemeter-client' };
+      local podLabels = $._config.commonLabels;
       local secretMount = containerVolumeMount.new(secretVolumeName, secretMountPath);
       local secretVolume = volume.fromSecret(secretVolumeName, secretName);
       local tlsMount = containerVolumeMount.new(tlsVolumeName, tlsMountPath);

--- a/manifests/client/deployment.yaml
+++ b/manifests/client/deployment.yaml
@@ -2,18 +2,21 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    k8s-app: telemeter-client
+    app.kubernetes.io/component: telemetry-metrics-collector
+    app.kubernetes.io/name: telemeter-client
   name: telemeter-client
   namespace: openshift-monitoring
 spec:
   replicas: 1
   selector:
     matchLabels:
-      k8s-app: telemeter-client
+      app.kubernetes.io/component: telemetry-metrics-collector
+      app.kubernetes.io/name: telemeter-client
   template:
     metadata:
       labels:
-        k8s-app: telemeter-client
+        app.kubernetes.io/component: telemetry-metrics-collector
+        app.kubernetes.io/name: telemeter-client
     spec:
       containers:
       - command:

--- a/manifests/client/service.yaml
+++ b/manifests/client/service.yaml
@@ -14,4 +14,5 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    k8s-app: telemeter-client
+    app.kubernetes.io/component: telemetry-metrics-collector
+    app.kubernetes.io/name: telemeter-client


### PR DESCRIPTION
To telemeter-client, add `app.kubernetes.io/part-of` label to [refer  at telemeter-client deployed by CMO](https://github.com/openshift/cluster-monitoring-operator/pull/1205/#discussion_r660375686) . 
