### PR TITLE
MON-1964: Increase limit receive bytes default to 128kB

### DIFF
--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -525,7 +525,7 @@ func (o *Options) Run(ctx context.Context, externalListener, internalListener ne
 				runutil.ExhaustCloseRequestBodyHandler(o.Logger,
 					server.InstrumentedHandler("receive",
 						authorize.NewHandler(o.Logger, &v2AuthorizeClient, authorizeURL, o.TenantKey,
-							receive.LimitBodySize(o.LimitReceiveBytes,
+							receive.LimitBodySize(o.Logger, o.LimitReceiveBytes,
 								receive.ValidateLabels(
 									o.Logger,
 									http.HandlerFunc(receiver.Receive),

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -135,11 +135,12 @@ func TestLimitBodySize(t *testing.T) {
 
 	var telemeterServer *httptest.Server
 	{
-		receiver := receive.NewHandler(log.NewNopLogger(), receiveServer.URL, prometheus.NewRegistry(), "default-tenant")
+		logger := log.NewNopLogger()
+		receiver := receive.NewHandler(logger, receiveServer.URL, prometheus.NewRegistry(), "default-tenant")
 
 		telemeterServer = httptest.NewServer(
 			fakeAuthorizeHandler(
-				receive.LimitBodySize(receive.DefaultRequestLimit,
+				receive.LimitBodySize(logger, receive.DefaultRequestLimit,
 					http.HandlerFunc(receiver.Receive),
 				),
 				&authorize.Client{ID: "test"},


### PR DESCRIPTION
There is a second commit that adds logging to `LimitBodySize`. Happy to discuss this one, just thought it would be handy to be able to get that info.