### PR TITLE
Bug 2016352: client: don't create empty service-ca.crt key in configmap

### DIFF
--- a/jsonnet/telemeter/client/kubernetes.libsonnet
+++ b/jsonnet/telemeter/client/kubernetes.libsonnet
@@ -230,7 +230,7 @@ local securePort = 8443;
     servingCertsCABundle+:
       local configmap = k.core.v1.configMap;
 
-      configmap.new('telemeter-client-serving-certs-ca-bundle', { [servingCertsCABundleFileName]: '' }) +
+      configmap.new('telemeter-client-serving-certs-ca-bundle') +
       configmap.mixin.metadata.withNamespace($._config.namespace) +
       configmap.mixin.metadata.withAnnotations({ 'service.alpha.openshift.io/inject-cabundle': 'true' }),
   },

--- a/manifests/client/servingCertsCABundle.yaml
+++ b/manifests/client/servingCertsCABundle.yaml
@@ -1,6 +1,5 @@
 apiVersion: v1
-data:
-  service-ca.crt: ""
+data: ""
 kind: ConfigMap
 metadata:
   annotations:


### PR DESCRIPTION
The configmap telemeter-client-serving-certs-ca-bundle is created with
an empty service-ca.crt key. Thus pods using this configmap can not
specify to be scheduled after the service-ca cert was actually created.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>