### PR TITLE
Fix telemeter image location in the CI benchmark job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,8 +176,12 @@ test-integration: build | $(THANOS_BIN) $(UP_BIN) $(MEMCACHED_BIN) $(PROMETHEUS_
 
 test-benchmark: build $(GOJSONTOYAML_BIN)
 	# Allow the image to be overridden when running in CI.
-	if [ -n "$$IMAGE_FORMAT" ]; then \
-	    f=$$(mktemp) && cat ./manifests/benchmark/statefulSetTelemeterServer.yaml | $(GOJSONTOYAML_BIN) --yamltojson | jq '.spec.template.spec.containers[].image="'"$${IMAGE_FORMAT//\$$\{component\}/telemeter}"'"' | $(GOJSONTOYAML_BIN) > $$f && mv $$f ./manifests/benchmark/statefulSetTelemeterServer.yaml; \
+	# The CI_TELEMETER_IMAGE environment variable is injected by the
+	# ci-operator. Check the configuration of the job in
+	# https://github.com/openshift/release.
+	if [ -n "$$CI_TELEMETER_IMAGE" ]; then \
+	    echo "Overriding telemeter image to $${CI_TELEMETER_IMAGE}"; \
+	    f=$$(mktemp) && cat ./manifests/benchmark/statefulSetTelemeterServer.yaml | $(GOJSONTOYAML_BIN) --yamltojson | jq '.spec.template.spec.containers[].image="'"$${CI_TELEMETER_IMAGE}"'"' | $(GOJSONTOYAML_BIN) > $$f && mv $$f ./manifests/benchmark/statefulSetTelemeterServer.yaml; \
 	fi
 	./test/benchmark.sh "" "" $(BENCHMARK_GOAL) "" $(BENCHMARK_GOAL)
 


### PR DESCRIPTION
The IMAGE_FORMAT environment variable has been deprecated and removed
which means that the test-benchmark target has been broken when launched
in a CI environment. We somehow fixed it in [0] but it isn't optimal
since the CI jobs should use the image built from the submitted code
change.
    
The OpenShift CI tooling allows to inject environment variables
referring to images but it has to be done explicitly [1]. There's a
pending change [2] in github.com/openshift/release to inject the
telemeter image location into the CI_TELEMETER_IMAGE variable.

[0] https://github.com/openshift/telemeter/commit/85d263366ab63104a988e789cecebbb7727fcf32
[1] https://docs.ci.openshift.org/docs/architecture/ci-operator/#referring-to-images-in-tests
[2] https://github.com/openshift/release/pull/23052