### PR TITLE
OWNERS: Add Jéssica Lins

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -17,6 +17,7 @@ reviewers:
 - matej-g
 - onprem
 - spaparaju
+- jessicalins
 
 approvers:
 - smarterclayton
@@ -35,6 +36,7 @@ approvers:
 - matej-g
 - onprem
 - spaparaju
+- jessicalins
 
 emeritus_approvers:
 - squat


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

Updates the OWNERS file to include Jéssica Lins (@jessicalins) from RHOBS team, who is currently missing.