### PR TITLE
client: Fix invalid serving-certs-ca configmap

### DIFF
--- a/jsonnet/telemeter/client/kubernetes.libsonnet
+++ b/jsonnet/telemeter/client/kubernetes.libsonnet
@@ -230,8 +230,8 @@ local securePort = 8443;
     servingCertsCABundle+:
       local configmap = k.core.v1.configMap;
 
-      configmap.new('telemeter-client-serving-certs-ca-bundle') +
+      configmap.new('telemeter-client-serving-certs-ca-bundle', {}) +
       configmap.mixin.metadata.withNamespace($._config.namespace) +
-      configmap.mixin.metadata.withAnnotations({ 'service.alpha.openshift.io/inject-cabundle': 'true' }),
+      configmap.mixin.metadata.withAnnotations({ 'service.beta.openshift.io/inject-cabundle': 'true' }),
   },
 }

--- a/manifests/client/servingCertsCABundle.yaml
+++ b/manifests/client/servingCertsCABundle.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-data: ""
+data: {}
 kind: ConfigMap
 metadata:
   annotations:
-    service.alpha.openshift.io/inject-cabundle: "true"
+    service.beta.openshift.io/inject-cabundle: "true"
   name: telemeter-client-serving-certs-ca-bundle
   namespace: openshift-monitoring


### PR DESCRIPTION
This commit fixes the invalid configmap definition created by https://github.com/openshift/telemeter/pull/398.
Also this moves to "service.beta.openshift.io/inject-cabundle" annotation.

Without this fix, following errors were seen while deploying CMO,

```
I1102 22:23:40.699907   50143 operator.go:603] ClusterOperator reconciliation failed (attempt 2), retrying.
E1102 22:23:40.699919   50143 operator.go:490] Syncing "openshift-monitoring/cluster-monitoring-config" failed
E1102 22:23:40.699928   50143 operator.go:491] sync "openshift-monitoring/cluster-monitoring-config" failed: cluster monitoring update failed (reason: UpdatingTelemeterClientFailed)
```

Blocks https://github.com/openshift/cluster-monitoring-operator/pull/1455

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>