### PR TITLE
Adds PrometheusRule telemetry that was previously hosted in cluster-monitoring-operator

### DIFF
--- a/jsonnet/telemeter/client/kubernetes.libsonnet
+++ b/jsonnet/telemeter/client/kubernetes.libsonnet
@@ -84,6 +84,7 @@ local securePort = 8443;
       clusterRoleBinding.mixin.roleRef.mixinInstance({ kind: 'ClusterRole' }) +
       clusterRoleBinding.withSubjects([{ kind: 'ServiceAccount', name: 'telemeter-client', namespace: $._config.namespace }]),
 
+
     deployment:
       local deployment = k.apps.v1.deployment;
       local container = k.apps.v1.deployment.mixin.spec.template.spec.containersType;
@@ -226,6 +227,28 @@ local securePort = 8443;
           ],
         },
       },
+
+    prometheusRule: {
+      apiVersion: 'monitoring.coreos.com/v1',
+      kind: 'PrometheusRule',
+      metadata: {
+        name: 'telemetry',
+        namespace: $._config.namespace,
+      },
+      spec: {
+        groups: [
+          {
+            name: 'telemeter.rules',
+            rules: [
+              {
+                record: 'cluster:telemetry_selected_series:count',
+                expr: 'max(federate_samples - federate_filtered_samples)',
+              },
+            ],
+          },
+        ],
+      },
+    },
 
     servingCertsCABundle+:
       local configmap = k.core.v1.configMap;

--- a/manifests/client/prometheusRule.yaml
+++ b/manifests/client/prometheusRule.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: telemetry
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: telemeter.rules
+    rules:
+    - expr: max(federate_samples - federate_filtered_samples)
+      record: cluster:telemetry_selected_series:count


### PR DESCRIPTION
Issue https://bugzilla.redhat.com/show_bug.cgi?id=2057832

Problem: Current recording rule expression isn't completely
accurate since it may count more series than what is effectively sent to telemeter.
Furthermore the PrometheusRule should be hosted by the telemeter project

Solution: Move the telemetry rule to the telemetry repo and for the
expression instead metrics from telemeter-client which capture
exactly the number of samples being sent.