### PR TITLE
Bump Telemeter rules evaluation interval to 3m

### DIFF
--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -4,7 +4,7 @@
       groups+: [
         {
           name: 'telemeter.rules',
-          interval: '1m',
+          interval: '3m',
           rules: [
             {
               record: 'name_reason:cluster_operator_degraded:count',


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

We are currently seeing a numerous alerts about long evaluation duration, due to the fact that some of the rules are now taking much longer to evaluate (presumably due to larger data set, some rules take now 30-60 seconds to evaluate, thus always exceeding the evaluation interval).

Based on the discussions (https://coreos.slack.com/archives/G79AW9Q7R/p1658752053857949), there actually does not seem to be a need to evaluate the rules every minute. Hence, I'm bumping the interval to alleviate the issue with evaluation duration.