### PR TITLE
Add rules for cluster CPU-hours and Instance-hours

### DIFF
--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -142,10 +142,9 @@
             {
               // OpenShift Cluster Instance-hours for the last hour
               // The divisor of scalar(count_over_time(vector(1)[1h:5m])) allows us to get an effective average value having "absent data" treated as 0.
-              // max(...) by (_id) is used ensure a single datapoint per cluster ID
               record: 'cluster:usage:workload:capacity_physical_instance_hours',
               expr: |||
-                max(sum_over_time(group(cluster:usage:workload:capacity_physical_cpu_cores:max:5m) by (_id)[1h:5m]) / scalar(count_over_time(vector(1)[1h:5m]))) by (_id)
+                max by(_id) (count_over_time(cluster:usage:workload:capacity_physical_cpu_cores:max:5m[1h:5m])) / scalar(count_over_time(vector(1)[1h:5m]))
               |||,
             },
           ],

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -131,16 +131,16 @@
               |||,
             },
             {
-              // OpenShift Cluster CPU-hours for the last hour
+              // OpenShift Cluster CPU-hours for the last hour.
               // The divisor of scalar(count_over_time(vector(1)[1h:5m])) allows us to get an effective average value having "absent data" treated as 0.
-              // max(...) by (_id) is used ensure a single datapoint per cluster ID
+              // max(...) by (_id) is used ensure a single datapoint per cluster ID.
               record: 'cluster:usage:workload:capacity_physical_cpu_hours',
               expr: |||
                 max by(_id) (sum_over_time(cluster:usage:workload:capacity_physical_cpu_cores:max:5m[1h:5m]) / scalar(count_over_time(vector(1)[1h:5m])))
               |||,
             },
             {
-              // OpenShift Cluster Instance-hours for the last hour
+              // OpenShift Cluster Instance-hours for the last hour.
               // The divisor of scalar(count_over_time(vector(1)[1h:5m])) allows us to get an effective average value having "absent data" treated as 0.
               record: 'cluster:usage:workload:capacity_physical_instance_hours',
               expr: |||

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -132,20 +132,20 @@
             },
             {
               // OpenShift Cluster CPU-hours for the last hour
-              // The divisor of count_over_time(vector(1)[1h:5m])) allows us to get an effective average value having "absent data" treated as 0.
+              // The divisor of scalar(count_over_time(vector(1)[1h:5m])) allows us to get an effective average value having "absent data" treated as 0.
               // max(...) by (_id) is used ensure a single datapoint per cluster ID
               record: 'cluster:usage:workload:capacity_physical_cpu_hours',
               expr: |||
-                max(sum_over_time(cluster:usage:workload:capacity_physical_cpu_cores:max:5m[1h:5m]) / count_over_time(vector(1)[1h:5m])) by (_id)
+                max(sum_over_time(cluster:usage:workload:capacity_physical_cpu_cores:max:5m[1h:5m]) / scalar(count_over_time(vector(1)[1h:5m]))) by (_id)
               |||,
             },
             {
               // OpenShift Cluster Instance-hours for the last hour
-              // The divisor of count_over_time(vector(1)[1h:5m])) allows us to get an effective average value having "absent data" treated as 0.
+              // The divisor of scalar(count_over_time(vector(1)[1h:5m])) allows us to get an effective average value having "absent data" treated as 0.
               // max(...) by (_id) is used ensure a single datapoint per cluster ID
               record: 'cluster:usage:workload:capacity_physical_instance_hours',
               expr: |||
-                max(sum_over_time(group(cluster:usage:workload:capacity_physical_cpu_cores:max:5m) by (_id)[1h:5m]) / count_over_time(vector(1)[1h:5m])) by (_id)
+                max(sum_over_time(group(cluster:usage:workload:capacity_physical_cpu_cores:max:5m) by (_id)[1h:5m]) / scalar(count_over_time(vector(1)[1h:5m]))) by (_id)
               |||,
             },
           ],

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -130,6 +130,24 @@
                 topk(500, sum (acm_managed_cluster_info) by (managed_cluster_id, cloud, created_via, endpoint, instance, job, namespace, pod, service, vendor, version))
               |||,
             },
+            {
+              // OpenShift Cluster CPU-hours for the last hour
+              // The divisor of count_over_time(vector(1)[1h:5m])) allows us to get an effective average value having "absent data" treated as 0.
+              // max(...) by (_id) is used ensure a single datapoint per cluster ID
+              record: 'cluster:usage:workload:capacity_physical_cpu_hours',
+              expr: |||
+                max(sum_over_time(cluster:usage:workload:capacity_physical_cpu_cores:max:5m[1h:5m]) / count_over_time(vector(1)[1h:5m])) by (_id)
+              |||,
+            },
+            {
+              // OpenShift Cluster Instance-hours for the last hour
+              // The divisor of count_over_time(vector(1)[1h:5m])) allows us to get an effective average value having "absent data" treated as 0.
+              // max(...) by (_id) is used ensure a single datapoint per cluster ID
+              record: 'cluster:usage:workload:capacity_physical_instance_hours',
+              expr: |||
+                max(sum_over_time(group(cluster:usage:workload:capacity_physical_cpu_cores:max:5m) by (_id)[1h:5m]) / count_over_time(vector(1)[1h:5m])) by (_id)
+              |||,
+            },
           ],
         },
       ],

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -136,7 +136,7 @@
               // max(...) by (_id) is used ensure a single datapoint per cluster ID
               record: 'cluster:usage:workload:capacity_physical_cpu_hours',
               expr: |||
-                max(sum_over_time(cluster:usage:workload:capacity_physical_cpu_cores:max:5m[1h:5m]) / scalar(count_over_time(vector(1)[1h:5m]))) by (_id)
+                max by(_id) (sum_over_time(cluster:usage:workload:capacity_physical_cpu_cores:max:5m[1h:5m]) / scalar(count_over_time(vector(1)[1h:5m])))
               |||,
             },
             {


### PR DESCRIPTION
These are intended to help simplify PromQL used by subscription watch,
as well as make it more visible to others.

Additionally, the encapsulation allows us to tweak the definition of
CPU-hours or instance-hours if better underlying metrics are made
available.

Note this is untested, but I'm happy to assist with testing, but I lack context/fixtures.