### PR TITLE
Bump Telemeter rules evaluation interval to 4m

### DIFF
--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -4,7 +4,7 @@
       groups+: [
         {
           name: 'telemeter.rules',
-          interval: '3m',
+          interval: '4m',
           rules: [
             {
               record: 'name_reason:cluster_operator_degraded:count',


### PR DESCRIPTION
This PR bumps the rules evaluation interval from 3m to 4m as we are still seeing flappy alerts due to long rule evaluation as per https://issues.redhat.com/browse/MON-2697. This is a follow-up to #417.