### PR TITLE
pkg/receive/handler: Use OIDC client

### DIFF
--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -512,6 +512,7 @@ func (o *Options) Run(ctx context.Context, externalListener, internalListener ne
 		// v2 routes
 		{
 			v2AuthorizeClient := authorizeClient
+			v2ForwardClient := forwardClient
 
 			if len(o.Memcacheds) > 0 {
 				mc := memcached.New(context.Background(), o.MemcachedInterval, o.MemcachedExpire, o.Memcacheds...)
@@ -519,7 +520,7 @@ func (o *Options) Run(ctx context.Context, externalListener, internalListener ne
 				v2AuthorizeClient.Transport = cache.NewRoundTripper(mc, tollbooth.ExtractToken, v2AuthorizeClient.Transport, l, prometheus.DefaultRegisterer)
 			}
 
-			receiver := receive.NewHandler(o.Logger, o.ForwardURL, prometheus.DefaultRegisterer, o.TenantID)
+			receiver := receive.NewHandler(o.Logger, o.ForwardURL, v2ForwardClient, prometheus.DefaultRegisterer, o.TenantID)
 
 			external.Handle("/metrics/v1/receive",
 				runutil.ExhaustCloseRequestBodyHandler(o.Logger,

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -38,14 +38,12 @@ type Handler struct {
 }
 
 // NewHandler returns a new Handler with a http client
-func NewHandler(logger log.Logger, forwardURL string, reg prometheus.Registerer, tenantID string) *Handler {
+func NewHandler(logger log.Logger, forwardURL string, client *http.Client, reg prometheus.Registerer, tenantID string) *Handler {
 	h := &Handler{
 		ForwardURL: forwardURL,
 		tenantID:   tenantID,
-		client: &http.Client{
-			Timeout: forwardTimeout,
-		},
-		logger: log.With(logger, "component", "receive/handler"),
+		client:     client,
+		logger:     log.With(logger, "component", "receive/handler"),
 		forwardRequestsTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "telemeter_forward_requests_total",

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -85,7 +85,7 @@ func TestReceiveValidateLabels(t *testing.T) {
 
 	var telemeterServer *httptest.Server
 	{
-		receiver := receive.NewHandler(log.NewNopLogger(), receiveServer.URL, prometheus.NewRegistry(), "default-tenant")
+		receiver := receive.NewHandler(log.NewNopLogger(), receiveServer.URL, &http.Client{}, prometheus.NewRegistry(), "default-tenant")
 
 		telemeterServer = httptest.NewServer(
 			fakeAuthorizeHandler(
@@ -136,7 +136,7 @@ func TestLimitBodySize(t *testing.T) {
 	var telemeterServer *httptest.Server
 	{
 		logger := log.NewNopLogger()
-		receiver := receive.NewHandler(logger, receiveServer.URL, prometheus.NewRegistry(), "default-tenant")
+		receiver := receive.NewHandler(logger, receiveServer.URL, &http.Client{}, prometheus.NewRegistry(), "default-tenant")
 
 		telemeterServer = httptest.NewServer(
 			fakeAuthorizeHandler(


### PR DESCRIPTION
This PR makes sure that /metrics/v1/receive handler uses the OIDC forwardClient to send requests to Observatorium API instead.