### PR TITLE
pkg/receive/handler: Add middleware to respect whitelist + elide

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -7,13 +7,16 @@ import (
 	"io/ioutil"
 	"net/http"
 	"time"
+	"unsafe"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/promql"
 )
 
 const forwardTimeout = 5 * time.Second
@@ -33,12 +36,14 @@ type Handler struct {
 	client     *http.Client
 	logger     log.Logger
 
+	elideLabelSet map[string]struct{}
+	matcherSets   [][]*labels.Matcher
 	// Metrics.
 	forwardRequestsTotal *prometheus.CounterVec
 }
 
 // NewHandler returns a new Handler with a http client
-func NewHandler(logger log.Logger, forwardURL string, client *http.Client, reg prometheus.Registerer, tenantID string) *Handler {
+func NewHandler(logger log.Logger, forwardURL string, client *http.Client, reg prometheus.Registerer, tenantID string, whitelistRules []string, elideLabels []string) (*Handler, error) {
 	h := &Handler{
 		ForwardURL: forwardURL,
 		tenantID:   tenantID,
@@ -52,11 +57,26 @@ func NewHandler(logger log.Logger, forwardURL string, client *http.Client, reg p
 		),
 	}
 
+	var ms [][]*labels.Matcher
+	for _, rule := range whitelistRules {
+		matchers, err := promql.ParseMetricSelector(rule)
+		if err != nil {
+			return nil, err
+		}
+		ms = append(ms, matchers)
+	}
+	h.matcherSets = ms
+
+	h.elideLabelSet = make(map[string]struct{})
+	for _, l := range elideLabels {
+		h.elideLabelSet[l] = struct{}{}
+	}
+
 	if reg != nil {
 		reg.MustRegister(h.forwardRequestsTotal)
 	}
 
-	return h
+	return h, nil
 }
 
 // Receive a remote-write request after it has been authenticated and forward it to Thanos
@@ -129,7 +149,6 @@ func LimitBodySize(logger log.Logger, limit int64, next http.Handler) http.Handl
 	}
 }
 
-// ErrRequiredLabelMissing is returned if a required label is missing from a metric
 var ErrRequiredLabelMissing = fmt.Errorf("a required label is missing from the metric")
 
 // ValidateLabels by checking each enforced label to be present in every time series
@@ -192,4 +211,81 @@ func ValidateLabels(logger log.Logger, next http.Handler, labels ...string) http
 
 		next.ServeHTTP(w, r)
 	}
+}
+
+func (h *Handler) TransformWriteRequest(logger log.Logger, next http.Handler) http.HandlerFunc {
+	logger = log.With(logger, "component", "receive", "middleware", "transformWriteRequest")
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			level.Error(logger).Log("msg", "failed to read body", "err", err)
+			http.Error(w, "failed to read body", http.StatusInternalServerError)
+			return
+		}
+		defer r.Body.Close()
+
+		content, err := snappy.Decode(nil, body)
+		if err != nil {
+			level.Warn(logger).Log("msg", "failed to decode request body", "err", err)
+			http.Error(w, "failed to decode request body", http.StatusBadRequest)
+			return
+		}
+
+		var wreq prompb.WriteRequest
+		if err := proto.Unmarshal(content, &wreq); err != nil {
+			level.Warn(logger).Log("msg", "failed to decode protobuf from body", "err", err)
+			http.Error(w, "failed to decode protobuf from body", http.StatusBadRequest)
+			return
+		}
+
+		// Only allow whitelisted metrics.
+		n := 0
+		for _, ts := range wreq.GetTimeseries() {
+			if h.matches(PrompbLabelsToPromLabels(ts.GetLabels())) {
+				// Remove elided labels.
+				for i, l := range ts.Labels {
+					if _, elide := h.elideLabelSet[l.Name]; elide {
+						ts.Labels = append(ts.Labels[:i], ts.Labels[i+1:]...)
+					}
+				}
+				wreq.Timeseries[n] = ts
+				n++
+			}
+		}
+		wreq.Timeseries = wreq.Timeseries[:n]
+
+		data, err := proto.Marshal(&wreq)
+		if err != nil {
+			msg := "failed to marshal proto"
+			level.Warn(logger).Log("msg", msg, "err", err)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+
+		compressed := snappy.Encode(nil, data)
+
+		// Set body to this buffer for other handlers to read.
+		r.Body = ioutil.NopCloser(bytes.NewBuffer(compressed))
+
+		next.ServeHTTP(w, r)
+	}
+}
+
+func (h *Handler) matches(l labels.Labels) bool {
+	if len(h.matcherSets) == 0 {
+		return true
+	}
+
+	for _, matchers := range h.matcherSets {
+		for _, m := range matchers {
+			if v := l.Get(m.Name); !m.Matches(v) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func PrompbLabelsToPromLabels(lset []prompb.Label) labels.Labels {
+	return *(*labels.Labels)(unsafe.Pointer(&lset))
 }

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -85,7 +85,10 @@ func TestReceiveValidateLabels(t *testing.T) {
 
 	var telemeterServer *httptest.Server
 	{
-		receiver := receive.NewHandler(log.NewNopLogger(), receiveServer.URL, &http.Client{}, prometheus.NewRegistry(), "default-tenant")
+		receiver, err := receive.NewHandler(log.NewNopLogger(), receiveServer.URL, &http.Client{}, prometheus.NewRegistry(), "default-tenant", nil, nil)
+		if err != nil {
+			t.Error("failed to initialize receive handler")
+		}
 
 		telemeterServer = httptest.NewServer(
 			fakeAuthorizeHandler(
@@ -136,7 +139,10 @@ func TestLimitBodySize(t *testing.T) {
 	var telemeterServer *httptest.Server
 	{
 		logger := log.NewNopLogger()
-		receiver := receive.NewHandler(logger, receiveServer.URL, &http.Client{}, prometheus.NewRegistry(), "default-tenant")
+		receiver, err := receive.NewHandler(logger, receiveServer.URL, &http.Client{}, prometheus.NewRegistry(), "default-tenant", nil, nil)
+		if err != nil {
+			t.Error("failed to initialize receive handler")
+		}
 
 		telemeterServer = httptest.NewServer(
 			fakeAuthorizeHandler(


### PR DESCRIPTION
This PR adds a `TransformWriteRequest` middlerware to /metrics/v1/receive, to allow applying whitelist rules and elide labels to remote write requests.