### PR TITLE
Forward: Add logic to sanitize labels

### DIFF
--- a/cmd/telemeter-server/main_e2e_test.go
+++ b/cmd/telemeter-server/main_e2e_test.go
@@ -37,27 +37,27 @@ var expectedTimeSeries = []prompb.TimeSeries{
 	{
 		Labels: []prompb.Label{
 			{Name: "__name__", Value: "up"},
+			{Name: "cluster", Value: "dynamic"},
 			{Name: "job", Value: "test"},
 			{Name: "label", Value: "value0"},
-			{Name: "cluster", Value: "dynamic"},
 		},
 		Samples: []prompb.Sample{{Value: 1}},
 	},
 	{
 		Labels: []prompb.Label{
 			{Name: "__name__", Value: "up"},
+			{Name: "cluster", Value: "dynamic"},
 			{Name: "job", Value: "test"},
 			{Name: "label", Value: "value1"},
-			{Name: "cluster", Value: "dynamic"},
 		},
 		Samples: []prompb.Sample{{Value: 1}},
 	},
 	{
 		Labels: []prompb.Label{
 			{Name: "__name__", Value: "up"},
+			{Name: "cluster", Value: "dynamic"},
 			{Name: "job", Value: "test"},
 			{Name: "label", Value: "value2"},
-			{Name: "cluster", Value: "dynamic"},
 		},
 		Samples: []prompb.Sample{{Value: 0}},
 	},

--- a/pkg/server/forward_test.go
+++ b/pkg/server/forward_test.go
@@ -20,6 +20,8 @@ func Test_convertToTimeseries(t *testing.T) {
 	fooLabelValue1 := "bar"
 	fooLabelValue2 := "baz"
 
+	emptyLabelName := ""
+
 	barMetricName := "bar_metric"
 	barHelp := "bar help text"
 	barLabelName := "bar"
@@ -148,6 +150,69 @@ func Test_convertToTimeseries(t *testing.T) {
 		}, {
 			Labels:  []prompb.Label{{Name: nameLabelName, Value: barMetricName}, {Name: barLabelName, Value: barLabelValue1}},
 			Samples: []prompb.Sample{{Value: value42, Timestamp: nowTimestamp}},
+		}},
+	}, {
+		name: "unsanitized",
+		in: &PartitionedMetrics{
+			ClusterID: "foo",
+			Families: []*clientmodel.MetricFamily{{
+				Name: &fooMetricName,
+				Help: &fooHelp,
+				Type: &counter,
+				Metric: []*clientmodel.Metric{{
+					Label:       []*clientmodel.LabelPair{{Name: &fooLabelName, Value: &fooLabelValue1}},
+					Counter:     &clientmodel.Counter{Value: &value42},
+					TimestampMs: &timestamp,
+				}, {
+					Label:       []*clientmodel.LabelPair{{Name: &fooLabelName, Value: &fooLabelValue2}},
+					Counter:     &clientmodel.Counter{Value: &value50},
+					TimestampMs: &timestamp,
+				}, {
+					// With empty label.
+					Label:       []*clientmodel.LabelPair{{Name: &emptyLabelName, Value: &fooLabelValue2}},
+					Counter:     &clientmodel.Counter{Value: &value50},
+					TimestampMs: &timestamp,
+				},
+				},
+			}, {
+				Name: &barMetricName,
+				Help: &barHelp,
+				Type: &counter,
+				Metric: []*clientmodel.Metric{{
+					Label:       []*clientmodel.LabelPair{{Name: &barLabelName, Value: &barLabelValue1}},
+					Counter:     &clientmodel.Counter{Value: &value42},
+					TimestampMs: &timestamp,
+				}, {
+					// With duplicate labels.
+					Label:       []*clientmodel.LabelPair{{Name: &fooLabelName, Value: &fooLabelValue2}, {Name: &fooLabelName, Value: &fooLabelValue2}},
+					Counter:     &clientmodel.Counter{Value: &value42},
+					TimestampMs: &timestamp,
+				}, {
+					// With out-of-order labels.
+					Label:       []*clientmodel.LabelPair{{Name: &fooLabelName, Value: &fooLabelValue2}, {Name: &barLabelName, Value: &barLabelValue1}},
+					Counter:     &clientmodel.Counter{Value: &value50},
+					TimestampMs: &timestamp,
+				}},
+			}},
+		},
+		want: []prompb.TimeSeries{{
+			Labels:  []prompb.Label{{Name: nameLabelName, Value: fooMetricName}, {Name: fooLabelName, Value: fooLabelValue1}},
+			Samples: []prompb.Sample{{Value: value42, Timestamp: nowTimestamp}},
+		}, {
+			Labels:  []prompb.Label{{Name: nameLabelName, Value: fooMetricName}, {Name: fooLabelName, Value: fooLabelValue2}},
+			Samples: []prompb.Sample{{Value: value50, Timestamp: nowTimestamp}},
+		}, {
+			Labels:  []prompb.Label{{Name: nameLabelName, Value: fooMetricName}},
+			Samples: []prompb.Sample{{Value: value50, Timestamp: nowTimestamp}},
+		}, {
+			Labels:  []prompb.Label{{Name: nameLabelName, Value: barMetricName}, {Name: barLabelName, Value: barLabelValue1}},
+			Samples: []prompb.Sample{{Value: value42, Timestamp: nowTimestamp}},
+		}, {
+			Labels:  []prompb.Label{{Name: nameLabelName, Value: barMetricName}, {Name: fooLabelName, Value: fooLabelValue2}},
+			Samples: []prompb.Sample{{Value: value42, Timestamp: nowTimestamp}},
+		}, {
+			Labels:  []prompb.Label{{Name: nameLabelName, Value: barMetricName}, {Name: barLabelName, Value: barLabelValue1}, {Name: fooLabelName, Value: fooLabelValue2}},
+			Samples: []prompb.Sample{{Value: value50, Timestamp: nowTimestamp}},
 		}},
 	}}
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

Since Thanos Receiver from version `0.28.0` will require the labels to be valid (ordered, no duplicates and no empty labels), we need to ensure whatever we receive from client will contain valid labels.

Added tests to the conversion method to test that sanitizing labels works.