### PR TITLE
Add Daniel Mellado to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -14,6 +14,7 @@ reviewers:
 - JoaoBraveCoding
 - juanrh
 - saswatamcode
+- danielmellado
 
 approvers:
 - bwplotka
@@ -29,6 +30,7 @@ approvers:
 - JoaoBraveCoding
 - juanrh
 - saswatamcode
+- danielmellado
 
 emeritus_approvers:
 - squat


### PR DESCRIPTION
This commit adds Daniel Mellado (@danielmellado) to OWNERS file.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>