### PR TITLE
Add 'hypershift' value to 'install_type' label

### DIFF
--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -64,11 +64,13 @@
                         label_replace(
                           label_replace(
                             label_replace(
-                              topk by (_id) (1, cluster_installer), "install_type", "upi", "type", "other"
-                            ), "install_type", "ipi", "type", "openshift-install"
-                          ), "install_type", "hive", "invoker", "hive"
-                        ), "install_type", "assisted-installer", "invoker", "assisted-installer"
-                      ), "install_type", "infrastructure-operator", "invoker", "assisted-installer-operator"
+                              label_replace(
+                                topk by (_id) (1, cluster_installer), "install_type", "upi", "type", "other"
+                              ), "install_type", "ipi", "type", "openshift-install"
+                            ), "install_type", "hive", "invoker", "hive"
+                          ), "install_type", "assisted-installer", "invoker", "assisted-installer"
+                        ), "install_type", "infrastructure-operator", "invoker", "assisted-installer-operator"
+                      ), "install_type", "hypershift", "invoker", "hypershift"
                     )
                   ) or on(_id) (
                     label_replace(


### PR DESCRIPTION
Clusters installed with an invoker value of 'hypershift' should get an install type of 'hypershift'. This will help us identify which clusters are installed by the hypershift operator vs standalone.