### PR TITLE
Replace 'hypershift-unknown' with 'unknown'

### DIFF
--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -45,7 +45,7 @@
             {
               record: 'id_provider',
               expr: |||
-                0 * topk by (_id) (1, count by (_id, provider) (label_replace(cluster_infrastructure_provider * 0 + 2, "provider", "$1", "type", "(.*)")) or on(_id) label_replace(max by (_id) (cluster_version{type="current"}*0+1), "provider", "", "provider", "") or on(_id) label_replace(max by (_id) (cluster:node_instance_type_count:sum*0), "provider", "hypershift-unknown", "provider", ""))
+                0 * topk by (_id) (1, group by (_id, provider) (label_replace(cluster_infrastructure_provider, "provider", "$1", "type", "(.*)")) or on(_id) label_replace(group by (_id) (cluster_version{type="current"}), "provider", "unknown", "provider", ""))
               |||,
             },
             {
@@ -74,7 +74,7 @@
                     label_replace(
                       count by (_id) (
                         cluster:virt_platform_nodes:sum
-                      ), "install_type", "hypershift-unknown", "install_type", ""
+                      ), "install_type", "unknown", "install_type", ""
                     )
                   ) * 0
                 ) * 0


### PR DESCRIPTION
When no infrastructure provider or no install type are reported by a cluster, the respective provider or install type is labeled as 'hypershift-unknown'. This causes confusion implying that these clusters have something to do with hypershift hosted clusters. This applies a value of 'unknown' instead.