### PR TITLE
Add metrics for telemeter receive path

### DIFF
--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -529,13 +529,10 @@ func (o *Options) Run(ctx context.Context, externalListener, internalListener ne
 				runutil.ExhaustCloseRequestBodyHandler(o.Logger,
 					server.InstrumentedHandler("receive",
 						authorize.NewHandler(o.Logger, &v2AuthorizeClient, authorizeURL, o.TenantKey,
-							receive.LimitBodySize(o.Logger, o.LimitReceiveBytes,
-								receive.ValidateLabels(
+							receiver.LimitBodySize(o.Logger, o.LimitReceiveBytes,
+								receiver.TransformAndValidateWriteRequest(
 									o.Logger,
-									receiver.TransformWriteRequest(
-										o.Logger,
-										http.HandlerFunc(receiver.Receive),
-									),
+									http.HandlerFunc(receiver.Receive),
 									o.clusterIDKey,
 								),
 							),

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -41,7 +41,9 @@ type Handler struct {
 	elideLabelSet map[string]struct{}
 	matcherSets   [][]*labels.Matcher
 	// Metrics.
-	forwardRequestsTotal *prometheus.CounterVec
+	forwardRequestsTotal   *prometheus.CounterVec
+	requestBodySizeLimited prometheus.Counter
+	requestMissingLabels   prometheus.Counter
 }
 
 // NewHandler returns a new Handler with a http client
@@ -56,6 +58,18 @@ func NewHandler(logger log.Logger, forwardURL string, client *http.Client, reg p
 				Name: "telemeter_forward_requests_total",
 				Help: "The number of forwarded remote-write requests.",
 			}, []string{"result"},
+		),
+		requestBodySizeLimited: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: "telemeter_receive_size_limited_total",
+				Help: "The number of remote write requests dropped due to body size.",
+			},
+		),
+		requestMissingLabels: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: "telemeter_receive_request_missing_labels_total",
+				Help: "The number of remote write requests dropped due to missing labels.",
+			},
 		),
 	}
 
@@ -76,6 +90,8 @@ func NewHandler(logger log.Logger, forwardURL string, client *http.Client, reg p
 
 	if reg != nil {
 		reg.MustRegister(h.forwardRequestsTotal)
+		reg.MustRegister(h.requestBodySizeLimited)
+		reg.MustRegister(h.requestMissingLabels)
 	}
 
 	return h, nil
@@ -94,6 +110,7 @@ func (h *Handler) Receive(w http.ResponseWriter, r *http.Request) {
 
 	req, err := http.NewRequest(http.MethodPost, h.ForwardURL, r.Body)
 	if err != nil {
+		h.forwardRequestsTotal.WithLabelValues("error").Inc()
 		level.Error(h.logger).Log("msg", "failed to create forward request", "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -127,12 +144,13 @@ func (h *Handler) Receive(w http.ResponseWriter, r *http.Request) {
 }
 
 // LimitBodySize is a middleware that check that the request body is not bigger than the limit
-func LimitBodySize(logger log.Logger, limit int64, next http.Handler) http.HandlerFunc {
-	logger = log.With(logger, "component", "receive", "middleware", "LimitBodySize")
+func (h *Handler) LimitBodySize(logger log.Logger, limit int64, next http.Handler) http.HandlerFunc {
+	logger = log.With(h.logger, "middleware", "LimitBodySize")
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
+			h.forwardRequestsTotal.WithLabelValues("error").Inc()
 			level.Error(logger).Log("msg", "failed to read body", "err", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -143,6 +161,7 @@ func LimitBodySize(logger log.Logger, limit int64, next http.Handler) http.Handl
 
 		if len(body) >= int(limit) {
 			level.Warn(logger).Log("msg", "request is too big", "req_size", len(body))
+			h.requestBodySizeLimited.Inc()
 			http.Error(w, "request too big", http.StatusRequestEntityTooLarge)
 			return
 		}
@@ -153,29 +172,21 @@ func LimitBodySize(logger log.Logger, limit int64, next http.Handler) http.Handl
 
 var ErrRequiredLabelMissing = fmt.Errorf("a required label is missing from the metric")
 
-// ValidateLabels by checking each enforced label to be present in every time series
-func ValidateLabels(logger log.Logger, next http.Handler, labels ...string) http.HandlerFunc {
-	logger = log.With(logger, "component", "receive", "middleware", "validateLabels")
-
-	labelmap := make(map[string]struct{})
-	for _, label := range labels {
-		labelmap[label] = struct{}{}
-	}
-
+func (h *Handler) TransformAndValidateWriteRequest(logger log.Logger, next http.Handler, labels ...string) http.HandlerFunc {
+	logger = log.With(h.logger, "middleware", "transformAndValidateWriteRequest")
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
+			h.forwardRequestsTotal.WithLabelValues("error").Inc()
 			level.Error(logger).Log("msg", "failed to read body", "err", err)
 			http.Error(w, "failed to read body", http.StatusInternalServerError)
 			return
 		}
 
-		// Set body to this buffer for other handlers to read
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
-
 		content, err := snappy.Decode(nil, body)
 		if err != nil {
+			h.forwardRequestsTotal.WithLabelValues("error").Inc()
 			level.Warn(logger).Log("msg", "failed to decode request body", "err", err)
 			http.Error(w, "failed to decode request body", http.StatusBadRequest)
 			return
@@ -183,15 +194,25 @@ func ValidateLabels(logger log.Logger, next http.Handler, labels ...string) http
 
 		var wreq prompb.WriteRequest
 		if err := proto.Unmarshal(content, &wreq); err != nil {
+			h.forwardRequestsTotal.WithLabelValues("error").Inc()
 			level.Warn(logger).Log("msg", "failed to decode protobuf from body", "err", err)
 			http.Error(w, "failed to decode protobuf from body", http.StatusBadRequest)
 			return
 		}
 
+		labelmap := make(map[string]struct{})
+		for _, label := range labels {
+			labelmap[label] = struct{}{}
+		}
+
+		// Only allow whitelisted & sanitized metrics.
+		n := 0
 		for _, ts := range wreq.GetTimeseries() {
-			// exit early if not enough labels anyway
+			// Check required labels.
+			// exit early if not enough labels anyway.
 			if len(ts.GetLabels()) < len(labels) {
 				level.Warn(logger).Log("msg", "request is missing required labels", "err", ErrRequiredLabelMissing)
+				h.requestMissingLabels.Inc()
 				http.Error(w, ErrRequiredLabelMissing.Error(), http.StatusBadRequest)
 				return
 			}
@@ -206,43 +227,11 @@ func ValidateLabels(logger log.Logger, next http.Handler, labels ...string) http
 
 			if len(labels) != found {
 				level.Warn(logger).Log("msg", "request is missing required labels", "err", ErrRequiredLabelMissing)
+				h.requestMissingLabels.Inc()
 				http.Error(w, ErrRequiredLabelMissing.Error(), http.StatusBadRequest)
 				return
 			}
-		}
 
-		next.ServeHTTP(w, r)
-	}
-}
-
-func (h *Handler) TransformWriteRequest(logger log.Logger, next http.Handler) http.HandlerFunc {
-	logger = log.With(h.logger, "middleware", "transformWriteRequest")
-	return func(w http.ResponseWriter, r *http.Request) {
-		defer r.Body.Close()
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			level.Error(logger).Log("msg", "failed to read body", "err", err)
-			http.Error(w, "failed to read body", http.StatusInternalServerError)
-			return
-		}
-
-		content, err := snappy.Decode(nil, body)
-		if err != nil {
-			level.Warn(logger).Log("msg", "failed to decode request body", "err", err)
-			http.Error(w, "failed to decode request body", http.StatusBadRequest)
-			return
-		}
-
-		var wreq prompb.WriteRequest
-		if err := proto.Unmarshal(content, &wreq); err != nil {
-			level.Warn(logger).Log("msg", "failed to decode protobuf from body", "err", err)
-			http.Error(w, "failed to decode protobuf from body", http.StatusBadRequest)
-			return
-		}
-
-		// Only allow whitelisted & sanitized metrics.
-		n := 0
-		for _, ts := range wreq.GetTimeseries() {
 			if h.matches(PrompbLabelsToPromLabels(ts.GetLabels())) {
 				lbls := ts.Labels[:0]
 				dedup := make(map[string]struct{})
@@ -275,6 +264,7 @@ func (h *Handler) TransformWriteRequest(logger log.Logger, next http.Handler) ht
 
 		data, err := proto.Marshal(&wreq)
 		if err != nil {
+			h.forwardRequestsTotal.WithLabelValues("error").Inc()
 			msg := "failed to marshal proto"
 			level.Warn(logger).Log("msg", msg, "err", err)
 			http.Error(w, msg, http.StatusInternalServerError)

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -92,7 +92,7 @@ func TestReceiveValidateLabels(t *testing.T) {
 
 		telemeterServer = httptest.NewServer(
 			fakeAuthorizeHandler(
-				receive.ValidateLabels(
+				receiver.TransformAndValidateWriteRequest(
 					log.NewNopLogger(),
 					http.HandlerFunc(receiver.Receive),
 					"__name__",
@@ -146,7 +146,7 @@ func TestLimitBodySize(t *testing.T) {
 
 		telemeterServer = httptest.NewServer(
 			fakeAuthorizeHandler(
-				receive.LimitBodySize(logger, receive.DefaultRequestLimit,
+				receiver.LimitBodySize(logger, receive.DefaultRequestLimit,
 					http.HandlerFunc(receiver.Receive),
 				),
 				&authorize.Client{ID: "test"},


### PR DESCRIPTION
This PR adds a couple of new counters to accurately measure any request failures due to body size limit and request label validations.

This also refactors handler to ensure we decode and encode remote-write protobufs only once for transforming/validating remote write requests.