### PR TITLE
server: Ensure logging level is flag is respected

### DIFF
--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -162,13 +162,12 @@ func main() {
 		fmt.Sprintf("The tracing endpoint type. Options: '%s', '%s'.", tracing.EndpointTypeAgent, tracing.EndpointTypeCollector))
 
 	l := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	l = level.NewFilter(l, logger.LogLevelFromString(opt.LogLevel))
 	l = log.WithPrefix(l, "ts", log.DefaultTimestampUTC)
 	l = log.WithPrefix(l, "caller", log.DefaultCaller)
 	stdlog.SetOutput(log.NewStdlibAdapter(l))
 	opt.Logger = l
-	level.Info(l).Log("msg", "Telemeter server initialized.")
 
+	level.Info(l).Log("msg", "Telemeter server initialized.")
 	if err := cmd.Execute(); err != nil {
 		level.Error(l).Log("err", err)
 		os.Exit(1)
@@ -249,6 +248,9 @@ func (o *Options) Run(ctx context.Context, externalListener, internalListener ne
 		}
 		o.RequiredLabels[values[0]] = values[1]
 	}
+
+	levelledOption := logger.LogLevelFromString(o.LogLevel)
+	o.Logger = level.NewFilter(o.Logger, levelledOption)
 
 	tp, err := tracing.InitTracer(
 		ctx,


### PR DESCRIPTION
The logging level was never respected since the flag value only become available within `Run`.

This change sets a levelled logger based on the value of the flag as expected!

Before and after screenshots of the debugger below.

<img width="586" alt="Screenshot 2023-02-03 at 16 15 26" src="https://user-images.githubusercontent.com/5781491/216654812-ce72b76c-4fcc-4af0-8dff-8a2f9b8790ea.png">
<img width="597" alt="Screenshot 2023-02-03 at 16 19 33" src="https://user-images.githubusercontent.com/5781491/216654840-d274b97b-dc88-464f-89ea-88749ee3e639.png">
