### PR TITLE
Use receive handler logger

### DIFF
--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -529,9 +529,8 @@ func (o *Options) Run(ctx context.Context, externalListener, internalListener ne
 				runutil.ExhaustCloseRequestBodyHandler(o.Logger,
 					server.InstrumentedHandler("receive",
 						authorize.NewHandler(o.Logger, &v2AuthorizeClient, authorizeURL, o.TenantKey,
-							receiver.LimitBodySize(o.Logger, o.LimitReceiveBytes,
+							receiver.LimitBodySize(o.LimitReceiveBytes,
 								receiver.TransformAndValidateWriteRequest(
-									o.Logger,
 									http.HandlerFunc(receiver.Receive),
 									o.clusterIDKey,
 								),

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -152,8 +152,8 @@ func (h *Handler) Receive(w http.ResponseWriter, r *http.Request) {
 }
 
 // LimitBodySize is a middleware that check that the request body is not bigger than the limit
-func (h *Handler) LimitBodySize(logger log.Logger, limit int64, next http.Handler) http.HandlerFunc {
-	logger = log.With(h.logger, "middleware", "LimitBodySize")
+func (h *Handler) LimitBodySize(limit int64, next http.Handler) http.HandlerFunc {
+	logger := log.With(h.logger, "middleware", "LimitBodySize")
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		body, err := ioutil.ReadAll(r.Body)
@@ -180,8 +180,8 @@ func (h *Handler) LimitBodySize(logger log.Logger, limit int64, next http.Handle
 
 var ErrRequiredLabelMissing = fmt.Errorf("a required label is missing from the metric")
 
-func (h *Handler) TransformAndValidateWriteRequest(logger log.Logger, next http.Handler, labels ...string) http.HandlerFunc {
-	logger = log.With(h.logger, "middleware", "transformAndValidateWriteRequest")
+func (h *Handler) TransformAndValidateWriteRequest(next http.Handler, labels ...string) http.HandlerFunc {
+	logger := log.With(h.logger, "middleware", "transformAndValidateWriteRequest")
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		body, err := io.ReadAll(r.Body)

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -93,7 +93,6 @@ func TestReceiveValidateLabels(t *testing.T) {
 		telemeterServer = httptest.NewServer(
 			fakeAuthorizeHandler(
 				receiver.TransformAndValidateWriteRequest(
-					log.NewNopLogger(),
 					http.HandlerFunc(receiver.Receive),
 					"__name__",
 				),
@@ -146,7 +145,7 @@ func TestLimitBodySize(t *testing.T) {
 
 		telemeterServer = httptest.NewServer(
 			fakeAuthorizeHandler(
-				receiver.LimitBodySize(logger, receive.DefaultRequestLimit,
+				receiver.LimitBodySize(receive.DefaultRequestLimit,
 					http.HandlerFunc(receiver.Receive),
 				),
 				&authorize.Client{ID: "test"},


### PR DESCRIPTION
This PR ensures that receive methods don't need a separate logger and use the one passed into `handler` itself. Mergeable after #449 goes in.