### PR TITLE
OCPBUGS-7702: Add 'agent-installer' value to 'install_type' label

### DIFF
--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -64,11 +64,13 @@
                         label_replace(
                           label_replace(
                             label_replace(
-                              topk by (_id) (1, cluster_installer), "install_type", "upi", "type", "other"
-                            ), "install_type", "ipi", "type", "openshift-install"
-                          ), "install_type", "hive", "invoker", "hive"
-                        ), "install_type", "assisted-installer", "invoker", "assisted-installer"
-                      ), "install_type", "infrastructure-operator", "invoker", "assisted-installer-operator"
+                              label_replace(
+                                topk by (_id) (1, cluster_installer), "install_type", "upi", "type", "other"
+                              ), "install_type", "ipi", "type", "openshift-install"
+                            ), "install_type", "hive", "invoker", "hive"
+                          ), "install_type", "assisted-installer", "invoker", "assisted-installer"
+                        ), "install_type", "infrastructure-operator", "invoker", "assisted-installer-operator"
+                      ), "install_type", "agent-installer", "invoker", "agent-installer"
                     )
                   ) or on(_id) (
                     label_replace(


### PR DESCRIPTION
Clusters installed with an invoker value of 'agent-installer' should get an install_type of 'agent-installer'.