### PR TITLE
MON-3230: Add TLS auth to telemeter-client

### DIFF
--- a/cmd/telemeter-client/main.go
+++ b/cmd/telemeter-client/main.go
@@ -48,6 +48,11 @@ func main() {
 
 	cmd.Flags().StringVar(&opt.Listen, "listen", opt.Listen, "A host:port to listen on for health and metrics.")
 	cmd.Flags().StringVar(&opt.From, "from", opt.From, "The Prometheus server to federate from.")
+
+	// TLS flags
+	cmd.Flags().StringVar(&opt.TLSCertFile, "tls-cert-file", "", "File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert)")
+	cmd.Flags().StringVar(&opt.TLSKey, "tls-private-key-file", "", "File containing the default x509 private key matching --tls-cert-file.")
+
 	cmd.Flags().StringVar(&opt.FromToken, "from-token", opt.FromToken, "A bearer token to use when authenticating to the source Prometheus server.")
 	cmd.Flags().StringVar(&opt.FromCAFile, "from-ca-file", opt.FromCAFile, "A file containing the CA certificate to use to verify the --from URL in addition to the system roots certificates.")
 	cmd.Flags().StringVar(&opt.FromTokenFile, "from-token-file", opt.FromTokenFile, "A file containing a bearer token to use when authenticating to the source Prometheus server.")
@@ -109,6 +114,8 @@ type Options struct {
 
 	From          string
 	To            string
+	TLSCertFile   string
+	TLSKey        string
 	ToUpload      string
 	ToAuthorize   string
 	FromCAFile    string
@@ -269,6 +276,8 @@ func (o *Options) Run() error {
 		FromTokenFile: o.FromTokenFile,
 		ToTokenFile:   o.ToTokenFile,
 		FromCAFile:    o.FromCAFile,
+		TLSCertFile:   o.TLSCertFile,
+		TLSKey:        o.TLSKey,
 
 		AnonymizeLabels:   o.AnonymizeLabels,
 		AnonymizeSalt:     o.AnonymizeSalt,

--- a/cmd/telemeter-client/main.go
+++ b/cmd/telemeter-client/main.go
@@ -51,7 +51,7 @@ func main() {
 
 	// TLS flags
 	cmd.Flags().StringVar(&opt.TLSCertFile, "tls-cert-file", "", "File containing the x509 public certificate to use when connecting to the Prometheus server.")
-	cmd.Flags().StringVar(&opt.TLSKey, "tls-private-key-file", "", "File containing the default x509 private key matching --tls-cert-file.")
+	cmd.Flags().StringVar(&opt.TLSKey, "tls-private-key-file", "", "File containing the  x509 private key to use when connecting to the Prometheus server. It should match with --tls-cert-file.")
 
 	cmd.Flags().StringVar(&opt.FromToken, "from-token", opt.FromToken, "A bearer token to use when authenticating to the source Prometheus server.")
 	cmd.Flags().StringVar(&opt.FromCAFile, "from-ca-file", opt.FromCAFile, "A file containing the CA certificate to use to verify the --from URL in addition to the system roots certificates.")

--- a/cmd/telemeter-client/main.go
+++ b/cmd/telemeter-client/main.go
@@ -50,7 +50,7 @@ func main() {
 	cmd.Flags().StringVar(&opt.From, "from", opt.From, "The Prometheus server to federate from.")
 
 	// TLS flags
-	cmd.Flags().StringVar(&opt.TLSCertFile, "tls-cert-file", "", "File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert)")
+	cmd.Flags().StringVar(&opt.TLSCertFile, "tls-cert-file", "", "File containing the x509 public certificate to use when connecting to the Prometheus server.")
 	cmd.Flags().StringVar(&opt.TLSKey, "tls-private-key-file", "", "File containing the default x509 private key matching --tls-cert-file.")
 
 	cmd.Flags().StringVar(&opt.FromToken, "from-token", opt.FromToken, "A bearer token to use when authenticating to the source Prometheus server.")

--- a/cmd/telemeter-client/main.go
+++ b/cmd/telemeter-client/main.go
@@ -51,7 +51,7 @@ func main() {
 
 	// TLS flags
 	cmd.Flags().StringVar(&opt.TLSCertFile, "tls-cert-file", "", "File containing the x509 public certificate to use when connecting to the Prometheus server.")
-	cmd.Flags().StringVar(&opt.TLSKey, "tls-private-key-file", "", "File containing the  x509 private key to use when connecting to the Prometheus server. It should match with --tls-cert-file.")
+	cmd.Flags().StringVar(&opt.TLSKey, "tls-private-key-file", "", "File containing the x509 private key to use when connecting to the Prometheus server. It should match with --tls-cert-file.")
 
 	cmd.Flags().StringVar(&opt.FromToken, "from-token", opt.FromToken, "A bearer token to use when authenticating to the source Prometheus server.")
 	cmd.Flags().StringVar(&opt.FromCAFile, "from-ca-file", opt.FromCAFile, "A file containing the CA certificate to use to verify the --from URL in addition to the system roots certificates.")

--- a/jsonnet/telemeter/client/kubernetes.libsonnet
+++ b/jsonnet/telemeter/client/kubernetes.libsonnet
@@ -2,9 +2,12 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
 local secretName = 'telemeter-client';
 local secretVolumeName = 'secret-telemeter-client';
 local secretMountPath = '/etc/telemeter';
-local tlsSecret = 'metrics-client-certs';
+local tlsSecret = 'telemeter-client-certs';
 local tlsVolumeName = 'telemeter-client-tls';
 local tlsMountPath = '/etc/tls/private';
+local federateSecret = 'federate-client-certs';
+local federateVolumeName = 'federate-client-tls';
+local federateMountPath = '/etc/tls/private';
 local servingCertsCABundle = 'serving-certs-ca-bundle';
 local servingCertsCABundleFileName = 'service-ca.crt';
 local servingCertsCABundleMountPath = '/etc/%s' % servingCertsCABundle;
@@ -98,6 +101,8 @@ local securePort = 8443;
       local secretVolume = volume.fromSecret(secretVolumeName, secretName);
       local tlsMount = containerVolumeMount.new(tlsVolumeName, tlsMountPath);
       local tlsVolume = volume.fromSecret(tlsVolumeName, tlsSecret);
+      local federateMount = containerVolumeMount.new(federateVolumeName, federateMountPath);
+      local federateVolume = volume.fromSecret(federateVolumeName, federateSecret);
       local sccabMount = containerVolumeMount.new(servingCertsCABundle, servingCertsCABundleMountPath);
       local sccabVolume = volume.withName(servingCertsCABundle) + volume.mixin.configMap.withName('telemeter-client-serving-certs-ca-bundle');
       local anonymize = containerEnv.new('ANONYMIZE_LABELS', std.join(',', $._config.telemeterClient.anonymizeLabels));
@@ -130,7 +135,7 @@ local securePort = 8443;
           '--anonymize-labels=$(ANONYMIZE_LABELS)',
         ] + matchRules) +
         container.withPorts(containerPort.newNamed(insecurePort, 'http')) +
-        container.withVolumeMounts([sccabMount, secretMount, tlsMount]) +
+        container.withVolumeMounts([sccabMount, secretMount, federateMount]) +
         container.withEnv([anonymize, from, id, to, httpProxy, httpsProxy, noProxy]) +
         container.mixin.resources.withRequests({ cpu: '1m', memory: '40Mi' });
 
@@ -165,7 +170,7 @@ local securePort = 8443;
       deployment.mixin.spec.template.spec.withServiceAccountName('telemeter-client') +
       deployment.mixin.spec.template.spec.withPriorityClassName('system-cluster-critical') +
       deployment.mixin.spec.template.spec.withNodeSelector({ 'kubernetes.io/os': 'linux' }) +
-      deployment.mixin.spec.template.spec.withVolumes([sccabVolume, secretVolume, tlsVolume]),
+      deployment.mixin.spec.template.spec.withVolumes([sccabVolume, secretVolume, tlsVolume, federateVolume]),
 
     secret:
       local secret = k.core.v1.secret;

--- a/manifests/client/deployment.yaml
+++ b/manifests/client/deployment.yaml
@@ -32,8 +32,6 @@ spec:
         - --listen=localhost:8080
         - --anonymize-salt-file=/etc/telemeter/salt
         - --anonymize-labels=$(ANONYMIZE_LABELS)
-        - --log-level=debug 
-        - -v
         env:
         - name: ANONYMIZE_LABELS
           value: ""
@@ -49,7 +47,7 @@ spec:
           value: ""
         - name: NO_PROXY
           value: ""
-        image: quay.io/mariofer/origin-telemeter:new_cert_v2
+        image: quay.io/openshift/origin-telemeter:v4.0
         name: telemeter-client
         ports:
         - containerPort: 8080
@@ -66,7 +64,7 @@ spec:
           name: secret-telemeter-client
           readOnly: false
         - mountPath: /etc/tls/private
-          name: telemeter-client-tls
+          name: federate-client-tls
           readOnly: false
       - args:
         - --webhook-url=http://localhost:8080/-/reload
@@ -111,5 +109,8 @@ spec:
         secret:
           secretName: telemeter-client
       - name: telemeter-client-tls
+        secret:
+          secretName: telemeter-client-certs
+      - name: federate-client-tls
         secret:
           secretName: federate-client-certs

--- a/manifests/client/deployment.yaml
+++ b/manifests/client/deployment.yaml
@@ -23,6 +23,8 @@ spec:
         - /usr/bin/telemeter-client
         - --id=$(ID)
         - --from=$(FROM)
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
         - --from-ca-file=/etc/serving-certs-ca-bundle/service-ca.crt
         - --from-token-file=/var/run/secrets/kubernetes.io/serviceaccount/token
         - --to=$(TO)
@@ -30,11 +32,13 @@ spec:
         - --listen=localhost:8080
         - --anonymize-salt-file=/etc/telemeter/salt
         - --anonymize-labels=$(ANONYMIZE_LABELS)
+        - --log-level=debug 
+        - -v
         env:
         - name: ANONYMIZE_LABELS
           value: ""
         - name: FROM
-          value: https://prometheus-k8s.openshift-monitoring.svc:9091
+          value: https://prometheus-k8s.openshift-monitoring.svc:9092
         - name: ID
           value: ""
         - name: TO
@@ -45,7 +49,7 @@ spec:
           value: ""
         - name: NO_PROXY
           value: ""
-        image: quay.io/openshift/origin-telemeter:v4.0
+        image: quay.io/mariofer/origin-telemeter:new_cert_v2
         name: telemeter-client
         ports:
         - containerPort: 8080
@@ -60,6 +64,9 @@ spec:
           readOnly: false
         - mountPath: /etc/telemeter
           name: secret-telemeter-client
+          readOnly: false
+        - mountPath: /etc/tls/private
+          name: telemeter-client-tls
           readOnly: false
       - args:
         - --webhook-url=http://localhost:8080/-/reload
@@ -105,4 +112,4 @@ spec:
           secretName: telemeter-client
       - name: telemeter-client-tls
         secret:
-          secretName: telemeter-client-tls
+          secretName: federate-client-certs

--- a/manifests/client/service.yaml
+++ b/manifests/client/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: metrics-client-certs
+    service.beta.openshift.io/serving-cert-secret-name: telemeter-client-certs
   labels:
     k8s-app: telemeter-client
   name: telemeter-client

--- a/manifests/client/service.yaml
+++ b/manifests/client/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: telemeter-client-tls
+    service.beta.openshift.io/serving-cert-secret-name: metrics-client-certs
   labels:
     k8s-app: telemeter-client
   name: telemeter-client

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -153,14 +153,18 @@ func New(cfg Config) (*Worker, error) {
 	fromClient := &http.Client{Transport: fromTransport}
 
 	if len(cfg.FromCAFile) > 0 {
-		level.Info(logger).Log("msg", "fromClient transport: CA file %s and TLS", cfg.FromCAFile)
+		level.Info(logger).Log("msg", "TLS configuration", "ca_file", cfg.FromCAFile, "cert_file", cfg.TLSCertFile, "key_file", cfg.TLSKey)
 
 		var cert tls.Certificate
 		var err error
-		if *&cfg.TLSCertFile != "" && *&cfg.TLSKey != "" {
+
+		if fromTransport.TLSClientConfig == nil {
+			fromTransport.TLSClientConfig = &tls.Config{}
+		}
+		if cfg.TLSCertFile != "" && cfg.TLSKey != "" {
 			cert, err = tls.LoadX509KeyPair(*&cfg.TLSCertFile, *&cfg.TLSKey)
 			if err != nil {
-				return nil, fmt.Errorf("Error creating x509 keypair from client cert file %s and client key file %s", *&cfg.TLSCertFile, *&cfg.TLSKey)
+				return nil, fmt.Errorf("error creating x509 keypair from client cert file %s and client key file %s", cfg.TLSCertFile, cfg.TLSKey)
 			}
 		}
 

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -184,30 +184,23 @@ func New(cfg Config) (*Worker, error) {
 			Certificates: []tls.Certificate{cert},
 			RootCAs:      pool,
 		}
-
-		fromClient.Transport = telemeterhttp.NewTLSRoundTripper(fromClient.Transport)
-
-	} else {
-		if cfg.Debug {
-			level.Info(logger).Log("msg", "fromClient transport: Debug ")
-			fromClient.Transport = telemeterhttp.NewDebugRoundTripper(logger, fromClient.Transport)
-		}
-
-		if len(cfg.FromToken) == 0 && len(cfg.FromTokenFile) > 0 {
-			level.Info(logger).Log("msg", "fromClient transport FromTokenFile")
-			data, err := ioutil.ReadFile(cfg.FromTokenFile)
-			if err != nil {
-				return nil, fmt.Errorf("unable to read from-token-file: %v", err)
-			}
-			cfg.FromToken = strings.TrimSpace(string(data))
-		}
-
-		if len(cfg.FromToken) > 0 {
-			level.Info(logger).Log("msg", "fromClient transport FromToken")
-			fromClient.Transport = telemeterhttp.NewBearerRoundTripper(cfg.FromToken, fromClient.Transport)
-		}
 	}
-
+	if cfg.Debug {
+		level.Info(logger).Log("msg", "fromClient transport: Debug ")
+		fromClient.Transport = telemeterhttp.NewDebugRoundTripper(logger, fromClient.Transport)
+	}
+	if len(cfg.FromToken) == 0 && len(cfg.FromTokenFile) > 0 {
+		level.Info(logger).Log("msg", "fromClient transport FromTokenFile")
+		data, err := ioutil.ReadFile(cfg.FromTokenFile)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read from-token-file: %v", err)
+		}
+		cfg.FromToken = strings.TrimSpace(string(data))
+	}
+	if len(cfg.FromToken) > 0 {
+		level.Info(logger).Log("msg", "fromClient transport FromToken")
+		fromClient.Transport = telemeterhttp.NewBearerRoundTripper(cfg.FromToken, fromClient.Transport)
+	}
 	w.fromClient = metricsclient.New(logger, fromClient, cfg.LimitBytes, w.interval, "federate_from")
 
 	// Create the `toClient`.

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -153,7 +153,7 @@ func New(cfg Config) (*Worker, error) {
 	fromClient := &http.Client{Transport: fromTransport}
 
 	if len(cfg.FromCAFile) > 0 {
-		level.Info(logger).Log("msg", "TLS configuration", "ca_file", cfg.FromCAFile, "cert_file", cfg.TLSCertFile, "key_file", cfg.TLSKey)
+		level.Debug(logger).Log("msg", "TLS configuration", "ca_file", cfg.FromCAFile, "cert_file", cfg.TLSCertFile, "key_file", cfg.TLSKey)
 
 		var cert tls.Certificate
 		var err error
@@ -186,11 +186,11 @@ func New(cfg Config) (*Worker, error) {
 		}
 	}
 	if cfg.Debug {
-		level.Info(logger).Log("msg", "fromClient transport: Debug ")
+		level.Debug(logger).Log("msg", "fromClient transport: Debug ")
 		fromClient.Transport = telemeterhttp.NewDebugRoundTripper(logger, fromClient.Transport)
 	}
 	if len(cfg.FromToken) == 0 && len(cfg.FromTokenFile) > 0 {
-		level.Info(logger).Log("msg", "fromClient transport FromTokenFile")
+		level.Debug(logger).Log("msg", "fromClient transport FromTokenFile")
 		data, err := ioutil.ReadFile(cfg.FromTokenFile)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read from-token-file: %v", err)
@@ -198,7 +198,7 @@ func New(cfg Config) (*Worker, error) {
 		cfg.FromToken = strings.TrimSpace(string(data))
 	}
 	if len(cfg.FromToken) > 0 {
-		level.Info(logger).Log("msg", "fromClient transport FromToken")
+		level.Debug(logger).Log("msg", "fromClient transport FromToken")
 		fromClient.Transport = telemeterhttp.NewBearerRoundTripper(cfg.FromToken, fromClient.Transport)
 	}
 	w.fromClient = metricsclient.New(logger, fromClient, cfg.LimitBytes, w.interval, "federate_from")

--- a/pkg/http/roundtripper.go
+++ b/pkg/http/roundtripper.go
@@ -37,6 +37,18 @@ func NewDebugRoundTripper(logger log.Logger, next http.RoundTripper) *debugRound
 	return &debugRoundTripper{next, log.With(logger, "component", "http/debugroundtripper")}
 }
 
+type TLSRoundTripper struct {
+	wrapper http.RoundTripper
+}
+
+func NewTLSRoundTripper(next http.RoundTripper) *TLSRoundTripper {
+	return &TLSRoundTripper{next}
+}
+
+func (rt *TLSRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return rt.wrapper.RoundTrip(req)
+}
+
 func (rt *debugRoundTripper) RoundTrip(req *http.Request) (res *http.Response, err error) {
 	reqd, _ := httputil.DumpRequest(req, false)
 	reqBody := bodyToString(&req.Body)

--- a/pkg/http/roundtripper.go
+++ b/pkg/http/roundtripper.go
@@ -37,18 +37,6 @@ func NewDebugRoundTripper(logger log.Logger, next http.RoundTripper) *debugRound
 	return &debugRoundTripper{next, log.With(logger, "component", "http/debugroundtripper")}
 }
 
-type TLSRoundTripper struct {
-	wrapper http.RoundTripper
-}
-
-func NewTLSRoundTripper(next http.RoundTripper) *TLSRoundTripper {
-	return &TLSRoundTripper{next}
-}
-
-func (rt *TLSRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	return rt.wrapper.RoundTrip(req)
-}
-
 func (rt *debugRoundTripper) RoundTrip(req *http.Request) (res *http.Response, err error) {
 	reqd, _ := httputil.DumpRequest(req, false)
 	reqBody := bodyToString(&req.Body)


### PR DESCRIPTION
## Description

Add TLS auth to forwarder in order to authorize telemeter against rbac Prometheus proxy. Change FROM to 9092 proxy port.

This PR works together with this CMO: https://github.com/openshift/cluster-monitoring-operator/pull/1904