### PR TITLE
Fix integration test documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,10 @@ This is [planned](https://github.com/openshift/cluster-monitoring-operator/pull/
 To see this in action, run
 
 ```
-make
-./test/integration.sh http://localhost:9005
+make test-integration
 ```
 
-The command launches a two instance `telemeter-server` cluster and a single `telemeter-client` to talk to that server, along with a Prometheus instance running on http://localhost:9005 that shows the federated metrics.
+The command launches a two instance `telemeter-server` cluster and a single `telemeter-client` to talk to that server, along with a Prometheus instance running on http://localhost:9090 that shows the federated metrics.
 The client will scrape metrics from the local Prometheus, then send those to the telemeter-server, which will then forward metrics to Thanos Receive, which can be queried via a Thanos Querier.
 
 To build binaries, run

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2,9 +2,6 @@
 
 # Runs a semi-realistic integration test with two servers, a stub authorization server, a 
 # prometheus that scrapes from them, and a single client that fetches "cluster" metrics.
-# If no arguments are passed an integration test scenario is run. Otherwise $1 becomes 
-# the upstream prometheus server to test against and $2 is an optional bearer token to 
-# authenticate the request.
 
 set -euo pipefail
 


### PR DESCRIPTION
Test documentation is old and not accurate. 

Command ./test/integration.sh has path of binaries broken, better use "make test-integration"
No args are passed to integration.sh
