### PR TITLE
rhelemeter: Validation of incoming metrics

### DIFF
--- a/cmd/rhelemeter-server/README.md
+++ b/cmd/rhelemeter-server/README.md
@@ -1,0 +1,75 @@
+# Rhelemeter
+
+Rhelemeter is a Prometheus remote write forward proxy. It allows RHEL hosts or an intermediate proxy to push metrics to
+a upstream Prometheus (or Prometheus remote write compatible) endpoint.
+
+[rhelemeter-server](https://github.com/openshift/telemeter/tree/master/cmd/rhelemeter-server) needs to receive
+and send metrics across security boundaries, and thus performs additional authorization and data integrity checks as required.
+
+Architecture
+```mermaid
+C4Deployment
+    title rhelemeter-server
+
+    Deployment_Node(rhel-os, "RHEL OS VM", ""){
+        Container(rhel, "Prometheus Remote Write Client", "", "Writes host OS based metrics.")
+    }
+
+    Deployment_Node(proxy, "Intermediate Proxy", ""){
+        Container(remote-write-proxy, "mTLS auth proxy", "", "Validates client certificate and forwards contents as header")
+    }
+        
+    Deployment_Node(rhelemeter, "rhelemeter-server", "Running in Red Hat infrastructure"){
+        Container(rhelemeter-server, "rhelemeter-server", "", "Validates sender and request contents and forwards upstream or rejects.")
+    }
+        
+    Deployment_Node(observatorium, "observatorium", ""){
+        Container(observatorium, "observatorium-api", "", "Performs authz and ingests metrics")
+    }
+        
+    Deployment_Node(sso, "SSO", "") {
+        Container(rh-sso, "Red Hat SSO", "", "Issues and validates tokens")
+    }
+        
+
+    Rel(rhel, remote-write-proxy, "Remote writes to", "")
+    Rel(remote-write-proxy, rhelemeter-server, "Forwards requests to", "")
+    Rel(rhelemeter-server, observatorium, "Forwards requests to", "")
+    Rel_R(rhelemeter-server, rh-sso, "Fetches token from")
+    Rel_R(observatorium, rh-sso, "Validates token with")
+
+    UpdateRelStyle(rhel, remote-write-proxy, $offsetX="-40", $offsetY="-30")   
+    UpdateRelStyle(remote-write-proxy, rhelemeter-server, $offsetY="-40")
+    UpdateRelStyle(rhelemeter-server, observatorium, $offsetY="-20", $offsetX="-50")
+    UpdateRelStyle(api, rh-sso, $offsetX="-40", $offsetY="-20")
+    UpdateRelStyle(observatorium, rh-sso, $offsetY="+40")
+```
+
+## Overview
+
+The server on startup fetches a token from the configured authorization server and uses that to forward
+requests to the upstream remote write endpoint. Tokens are refreshed automatically when they expire.
+
+The server supports two modes of operation:
+
+### Intermediate auth proxy
+This is the flow described in the diagram above. The proxy is responsible for validating the client certificate and
+forwarding the contents of the request as a headers. The server then validates the header using a pre-shared key
+and forwards the request to the upstream as configured.
+
+The `client-info-data-file` flag is used to specify the header names used to extract client info data.
+
+
+Optionally, the `client-info-subject-label` flag can be used to specify a label name to store the client subject.
+If present, the labels value on each time series much match the common name as forwarded by the proxy.
+If set, the server expects the header to be present in the following format where `x-rh-certauth-cn` 
+is configurable as described above:
+
+```bash
+x-rh-certauth-cn:  ${Certificate Subject}  
+// Example  Certificate Subject ->  "/O = 1234567, /CN = 1234567-9b7c-48f6-8d5b-7654321```
+```
+
+### mTLS
+The server is responsible for validating and decoding the client certificate and determining the client identity.
+

--- a/cmd/rhelemeter-server/main.go
+++ b/cmd/rhelemeter-server/main.go
@@ -345,10 +345,10 @@ func (o *Options) Run(ctx context.Context, externalListener, internalListener ne
 		mux := http.NewServeMux()
 		external.Mount("/", mux)
 
-		labelValidator := make(map[string]string)
+		labelValidator := make(map[string]interface{})
 		if o.ClientInfoSubjectLabel != "" {
 			level.Info(o.Logger).Log("msg", "using client cert subject label", "label", o.ClientInfoSubjectLabel)
-			labelValidator[o.ClientInfoSubjectLabel] = ssl.CommonNameContextKey
+			labelValidator[o.ClientInfoSubjectLabel] = ssl.CommonNameContextKey{}
 		}
 
 		// rhelemeter routes

--- a/cmd/telemeter-server/main.go
+++ b/cmd/telemeter-server/main.go
@@ -523,7 +523,7 @@ func (o *Options) Run(ctx context.Context, externalListener, internalListener ne
 				v2AuthorizeClient.Transport = cache.NewRoundTripper(mc, tollbooth.ExtractToken, v2AuthorizeClient.Transport, l, prometheus.DefaultRegisterer)
 			}
 
-			receiver, err := receive.NewHandler(o.Logger, o.ForwardURL, v2ForwardClient, prometheus.DefaultRegisterer, o.TenantID, o.Whitelist, o.ElideLabels)
+			receiver, err := receive.NewHandler(o.Logger, o.ForwardURL, v2ForwardClient, prometheus.DefaultRegisterer, o.TenantID, o.Whitelist, o.ElideLabels, nil)
 			if err != nil {
 				level.Error(o.Logger).Log("msg", "could not initialize receive handler", "err", err)
 			}

--- a/pkg/authorize/ssl/ssl.go
+++ b/pkg/authorize/ssl/ssl.go
@@ -64,8 +64,8 @@ func ClientCertInfoAsHeaders(config ClientCertConfig, logger log.Logger) func(ht
 
 			cnInfo := r.Header.Get(config.Config.CommonNameHeader)
 			if cnInfo == "" {
-				level.Info(logger).Log("msg", "invalid format for organisation and CN", "cnInfo", cnInfo)
-				http.Error(w, fmt.Sprintf("subject is empty. organisation and common name must be sent in request header %s",
+				level.Info(logger).Log("msg", "invalid format for O and CN", "cnInfo", cnInfo)
+				http.Error(w, fmt.Sprintf("subject is empty. Organisation and Common Name name must be sent in request header %s",
 					config.Config.CommonNameHeader), http.StatusForbidden)
 				return
 			}
@@ -74,7 +74,7 @@ func ClientCertInfoAsHeaders(config ClientCertConfig, logger log.Logger) func(ht
 			parts := strings.Split(cnInfo, ",")
 			if len(parts) != 2 {
 				level.Info(logger).Log("msg", "invalid format for organisation and CN", "cnInfo", cnInfo)
-				http.Error(w, fmt.Sprintf("invalid format for organisation and CN %s",
+				http.Error(w, fmt.Sprintf("invalid format for Organisation and Common Name in http header %s",
 					config.Config.CommonNameHeader), http.StatusForbidden)
 				return
 			}
@@ -83,8 +83,8 @@ func ClientCertInfoAsHeaders(config ClientCertConfig, logger log.Logger) func(ht
 			for i, part := range parts {
 				subPart := strings.Split(part, "=")
 				if len(subPart) != 2 {
-					level.Info(logger).Log("msg", "invalid format for organisation and CN", "cnInfo", cnInfo)
-					http.Error(w, fmt.Sprintf("invalid format for organisation and CN %s",
+					level.Info(logger).Log("msg", "invalid format for O and CN", "cnInfo", cnInfo)
+					http.Error(w, fmt.Sprintf("invalid format for Organisation and Common Name in http header %s",
 						config.Config.CommonNameHeader), http.StatusForbidden)
 					return
 				}
@@ -92,7 +92,7 @@ func ClientCertInfoAsHeaders(config ClientCertConfig, logger log.Logger) func(ht
 				case 0:
 					if strings.TrimSpace(subPart[0]) != "/O" {
 						level.Info(logger).Log("msg", "invalid format for organisation and CN", "cnInfo", cnInfo)
-						http.Error(w, fmt.Sprintf("invalid format for organisation and CN %s",
+						http.Error(w, fmt.Sprintf("invalid format for Organisation and Common Name in http header %s",
 							config.Config.CommonNameHeader), http.StatusForbidden)
 						return
 
@@ -102,7 +102,7 @@ func ClientCertInfoAsHeaders(config ClientCertConfig, logger log.Logger) func(ht
 				case 1:
 					if strings.TrimSpace(subPart[0]) != "/CN" {
 						level.Info(logger).Log("msg", "invalid format for organisation and CN", "cnInfo", cnInfo)
-						http.Error(w, fmt.Sprintf("invalid format for organisation and CN %s",
+						http.Error(w, fmt.Sprintf("invalid format for Organisation and Common Name in http header %s",
 							config.Config.CommonNameHeader), http.StatusForbidden)
 						return
 					}

--- a/pkg/authorize/ssl/ssl.go
+++ b/pkg/authorize/ssl/ssl.go
@@ -11,10 +11,8 @@ import (
 	"github.com/go-kit/log/level"
 )
 
-const (
-	OrganizationContextKey = "org"
-	CommonNameContextKey   = "common_name"
-)
+type OrganizationContextKey struct{}
+type CommonNameContextKey struct{}
 
 // ClientCertConfig allows middleware to extract client information from the request
 type ClientCertConfig struct {
@@ -99,7 +97,7 @@ func ClientCertInfoAsHeaders(config ClientCertConfig, logger log.Logger) func(ht
 						return
 
 					}
-					ctx = context.WithValue(ctx, OrganizationContextKey, strings.TrimSpace(subPart[1]))
+					ctx = context.WithValue(ctx, OrganizationContextKey{}, strings.TrimSpace(subPart[1]))
 
 				case 1:
 					if strings.TrimSpace(subPart[0]) != "/CN" {
@@ -108,7 +106,7 @@ func ClientCertInfoAsHeaders(config ClientCertConfig, logger log.Logger) func(ht
 							config.Config.CommonNameHeader), http.StatusForbidden)
 						return
 					}
-					ctx = context.WithValue(ctx, CommonNameContextKey, strings.TrimSpace(subPart[1]))
+					ctx = context.WithValue(ctx, CommonNameContextKey{}, strings.TrimSpace(subPart[1]))
 				}
 
 			}

--- a/pkg/authorize/ssl/ssl_test.go
+++ b/pkg/authorize/ssl/ssl_test.go
@@ -24,12 +24,12 @@ func TestClientCertInfoAsHeaders(t *testing.T) {
 	testMiddleware := func(t *testing.T, name string) func(http.Handler) http.Handler {
 		return func(next http.Handler) http.Handler {
 			fn := func(w http.ResponseWriter, r *http.Request) {
-				expectCN, ok := r.Context().Value(CommonNameContextKey).(string)
-				if !ok || r.Context().Value(CommonNameContextKey) != expectCn {
+				expectCN, ok := r.Context().Value(CommonNameContextKey{}).(string)
+				if !ok || r.Context().Value(CommonNameContextKey{}) != expectCn {
 					t.Errorf("%s: expected %s, got %s", name, expectCn, expectCN)
 				}
-				expectOrg, ok := r.Context().Value(OrganizationContextKey).(string)
-				if !ok || r.Context().Value(OrganizationContextKey) != expectO {
+				expectOrg, ok := r.Context().Value(CommonNameContextKey{}).(string)
+				if !ok || r.Context().Value(OrganizationContextKey{}) != expectO {
 					t.Errorf("%s: expected %s, got %s", name, expectO, expectOrg)
 				}
 

--- a/pkg/authorize/ssl/ssl_test.go
+++ b/pkg/authorize/ssl/ssl_test.go
@@ -1,6 +1,7 @@
 package ssl
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,12 +13,37 @@ func TestClientCertInfoAsHeaders(t *testing.T) {
 	const (
 		secret  = "abc"
 		xSecret = "x-secret"
+		xCn     = "x-cn"
+
+		expectO  = "test-O"
+		expectCn = "test-CN"
 	)
+
+	// test function to validate the context has been set in previously in middleware
+	// chain when ClientCertInfoAsHeaders is called
+	testMiddleware := func(t *testing.T, name string) func(http.Handler) http.Handler {
+		return func(next http.Handler) http.Handler {
+			fn := func(w http.ResponseWriter, r *http.Request) {
+				expectCN, ok := r.Context().Value(CommonNameContextKey).(string)
+				if !ok || r.Context().Value(CommonNameContextKey) != expectCn {
+					t.Errorf("%s: expected %s, got %s", name, expectCn, expectCN)
+				}
+				expectOrg, ok := r.Context().Value(OrganizationContextKey).(string)
+				if !ok || r.Context().Value(OrganizationContextKey) != expectO {
+					t.Errorf("%s: expected %s, got %s", name, expectO, expectOrg)
+				}
+
+				next.ServeHTTP(w, r)
+			}
+			return http.HandlerFunc(fn)
+		}
+	}
+
 	conf := ClientCertConfig{
 		Secret: secret,
 		Config: ClientCertInfo{
 			SecretHeader:     xSecret,
-			CommonNameHeader: "x-cn",
+			CommonNameHeader: xCn,
 			IssuerHeader:     "x-issuer",
 		},
 	}
@@ -54,9 +80,28 @@ func TestClientCertInfoAsHeaders(t *testing.T) {
 			expect: http.StatusForbidden,
 		},
 		{
+			name: "Test missing CN returns 403",
+			request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "http://test.com", nil)
+				req.Header.Set(xCn, "")
+				return req
+			},
+			expect: http.StatusForbidden,
+		},
+		{
+			name: "Test invalid CN returns 403",
+			request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "http://test.com", nil)
+				req.Header.Set(xCn, "any")
+				return req
+			},
+			expect: http.StatusForbidden,
+		},
+		{
 			name: "Test happy path",
 			request: func() *http.Request {
 				req := httptest.NewRequest(http.MethodGet, "http://test.com", nil)
+				req.Header.Set(xCn, fmt.Sprintf("/O = %s, /CN = %s", expectO, expectCn))
 				req.Header.Set(xSecret, secret)
 				return req
 			},
@@ -65,17 +110,21 @@ func TestClientCertInfoAsHeaders(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		handler := func(w http.ResponseWriter, r *http.Request) {}
-		req := tc.request()
-		res := httptest.NewRecorder()
-		handler(res, req)
+		t.Run(tc.name, func(t *testing.T) {
+			handler := func(w http.ResponseWriter, r *http.Request) {}
+			req := tc.request()
+			res := httptest.NewRecorder()
+			handler(res, req)
 
-		middleware := ClientCertInfoAsHeaders(conf, log.NewNopLogger())
-		srv := middleware(http.HandlerFunc(handler))
-		srv.ServeHTTP(res, req)
+			mw := testMiddleware(t, tc.name)
+			middlewareUnderTest := ClientCertInfoAsHeaders(conf, log.NewNopLogger())
+			srv := middlewareUnderTest(mw(http.HandlerFunc(handler)))
+			srv.ServeHTTP(res, req)
 
-		if res.Code != tc.expect {
-			t.Errorf("expected %d, got %d", tc.expect, res.Code)
-		}
+			if res.Code != tc.expect {
+				t.Errorf("%s: expected %d, got %d", tc.name, tc.expect, res.Code)
+			}
+		})
+
 	}
 }

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -307,19 +307,21 @@ func (h *Handler) TransformAndValidateWriteRequest(next http.Handler, labels ...
 			return
 		}
 
-		for _, ts := range wreq.GetTimeseries() {
-			for _, l := range ts.GetLabels() {
-				// Check for required label values.
-				if required, ok := h.requiredLabelValues[l.Name]; ok {
-					value, ok := r.Context().Value(required).(string)
-					if !ok || value != l.Value {
-						level.Warn(logger).Log(
-							"msg", "request is missing required label value",
-							"label", l.Name, "ctx_value", value, "label_value", l.Value, "err", ErrRequiredLabelValueIncorrect,
-						)
-						h.requestIncorrectLabelValues.Inc()
-						http.Error(w, ErrRequiredLabelValueIncorrect.Error(), http.StatusBadRequest)
-						return
+		if len(h.requiredLabelValues) > 0 {
+			for _, ts := range wreq.GetTimeseries() {
+				for _, l := range ts.GetLabels() {
+					// Check for required label values.
+					if required, ok := h.requiredLabelValues[l.Name]; ok {
+						value, ok := r.Context().Value(required).(string)
+						if !ok || value != l.Value {
+							level.Warn(logger).Log(
+								"msg", "request is missing required label value",
+								"label", l.Name, "ctx_value", value, "label_value", l.Value, "err", ErrRequiredLabelValueIncorrect,
+							)
+							h.requestIncorrectLabelValues.Inc()
+							http.Error(w, ErrRequiredLabelValueIncorrect.Error(), http.StatusBadRequest)
+							return
+						}
 					}
 				}
 			}

--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sort"
 	"time"
@@ -39,17 +38,20 @@ type Handler struct {
 	client     *http.Client
 	logger     log.Logger
 
-	elideLabelSet map[string]struct{}
-	matcherSets   [][]*labels.Matcher
+	elideLabelSet       map[string]struct{}
+	matcherSets         [][]*labels.Matcher
+	requiredLabelValues map[string]string
 	// Metrics.
-	forwardRequestsTotal   *prometheus.CounterVec
-	requestBodySizeLimited prometheus.Counter
-	requestMissingLabels   prometheus.Counter
-	seriesProcessedTotal   prometheus.Counter
+	forwardRequestsTotal        *prometheus.CounterVec
+	requestBodySizeLimited      prometheus.Counter
+	requestMissingLabels        prometheus.Counter
+	seriesProcessedTotal        prometheus.Counter
+	requestIncorrectLabelValues prometheus.Counter
 }
 
 // NewHandler returns a new Handler with a http client
-func NewHandler(logger log.Logger, forwardURL string, client *http.Client, reg prometheus.Registerer, tenantID string, whitelistRules []string, elideLabels []string) (*Handler, error) {
+func NewHandler(logger log.Logger, forwardURL string, client *http.Client, reg prometheus.Registerer, tenantID string,
+	whitelistRules []string, elideLabels []string, requiredLabelValsFromCtx map[string]string) (*Handler, error) {
 	h := &Handler{
 		ForwardURL: forwardURL,
 		tenantID:   tenantID,
@@ -71,6 +73,12 @@ func NewHandler(logger log.Logger, forwardURL string, client *http.Client, reg p
 			prometheus.CounterOpts{
 				Name: "telemeter_receive_request_missing_labels_total",
 				Help: "The number of remote write requests dropped due to missing labels.",
+			},
+		),
+		requestIncorrectLabelValues: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: "telemeter_receive_request_incorrect_label_values_total",
+				Help: "The number of remote write requests dropped due to missing incorrect label values.",
 			},
 		),
 		seriesProcessedTotal: prometheus.NewCounter(
@@ -102,6 +110,8 @@ func NewHandler(logger log.Logger, forwardURL string, client *http.Client, reg p
 		reg.MustRegister(h.requestMissingLabels)
 		reg.MustRegister(h.seriesProcessedTotal)
 	}
+
+	h.requiredLabelValues = requiredLabelValsFromCtx
 
 	return h, nil
 }
@@ -140,7 +150,7 @@ func (h *Handler) Receive(w http.ResponseWriter, r *http.Request) {
 
 	if resp.StatusCode/100 != 2 {
 		// Return upstream error as well.
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		msg := fmt.Sprintf("upstream response status is not 200 OK: %s", body)
 		if err != nil {
 			msg = fmt.Sprintf("upstream response status is not 200 OK: couldn't read body %v", err)
@@ -162,7 +172,7 @@ func (h *Handler) LimitBodySize(limit int64, next http.Handler) http.HandlerFunc
 		logger := log.With(logger, "request", middleware.GetReqID(r.Context()))
 
 		defer r.Body.Close()
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			h.forwardRequestsTotal.WithLabelValues("error").Inc()
 			level.Error(logger).Log("msg", "failed to read body", "err", err)
@@ -171,7 +181,7 @@ func (h *Handler) LimitBodySize(limit int64, next http.Handler) http.HandlerFunc
 		}
 
 		// Set body to this buffer for other handlers to read
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+		r.Body = io.NopCloser(bytes.NewBuffer(body))
 
 		if len(body) >= int(limit) {
 			level.Warn(logger).Log("msg", "request is too big", "req_size", len(body))
@@ -184,7 +194,10 @@ func (h *Handler) LimitBodySize(limit int64, next http.Handler) http.HandlerFunc
 	}
 }
 
-var ErrRequiredLabelMissing = fmt.Errorf("a required label is missing from the metric")
+var (
+	ErrRequiredLabelMissing        = fmt.Errorf("a required label is missing from the metric")
+	ErrRequiredLabelValueIncorrect = fmt.Errorf("a required label value is incorrect")
+)
 
 func (h *Handler) TransformAndValidateWriteRequest(next http.Handler, labels ...string) http.HandlerFunc {
 	logger := log.With(h.logger, "middleware", "transformAndValidateWriteRequest")
@@ -294,6 +307,24 @@ func (h *Handler) TransformAndValidateWriteRequest(next http.Handler, labels ...
 			return
 		}
 
+		for _, ts := range wreq.GetTimeseries() {
+			for _, l := range ts.GetLabels() {
+				// Check for required label values.
+				if required, ok := h.requiredLabelValues[l.Name]; ok {
+					value := r.Context().Value(required)
+					if value == nil || value.(string) != l.Value {
+						level.Warn(logger).Log(
+							"msg", "request is missing required label value",
+							"label", l.Name, "ctx_value", value.(string), "value", l.Value, "err", ErrRequiredLabelValueIncorrect,
+						)
+						h.requestIncorrectLabelValues.Inc()
+						http.Error(w, ErrRequiredLabelValueIncorrect.Error(), http.StatusBadRequest)
+						return
+					}
+				}
+			}
+		}
+
 		data, err := proto.Marshal(&wreq)
 		if err != nil {
 			h.forwardRequestsTotal.WithLabelValues("error").Inc()
@@ -306,7 +337,7 @@ func (h *Handler) TransformAndValidateWriteRequest(next http.Handler, labels ...
 		compressed := snappy.Encode(nil, data)
 
 		// Set body to this buffer for other handlers to read.
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(compressed))
+		r.Body = io.NopCloser(bytes.NewBuffer(compressed))
 
 		next.ServeHTTP(w, r)
 	}

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -85,7 +85,7 @@ func TestReceiveValidateLabels(t *testing.T) {
 
 	var telemeterServer *httptest.Server
 	{
-		receiver, err := receive.NewHandler(log.NewNopLogger(), receiveServer.URL, &http.Client{}, prometheus.NewRegistry(), "default-tenant", nil, nil)
+		receiver, err := receive.NewHandler(log.NewNopLogger(), receiveServer.URL, &http.Client{}, prometheus.NewRegistry(), "default-tenant", nil, nil, nil)
 		if err != nil {
 			t.Error("failed to initialize receive handler")
 		}
@@ -138,7 +138,7 @@ func TestLimitBodySize(t *testing.T) {
 	var telemeterServer *httptest.Server
 	{
 		logger := log.NewNopLogger()
-		receiver, err := receive.NewHandler(logger, receiveServer.URL, &http.Client{}, prometheus.NewRegistry(), "default-tenant", nil, nil)
+		receiver, err := receive.NewHandler(logger, receiveServer.URL, &http.Client{}, prometheus.NewRegistry(), "default-tenant", nil, nil, nil)
 		if err != nil {
 			t.Error("failed to initialize receive handler")
 		}


### PR DESCRIPTION
The rhelemeter server exposes remote write API and this change allows us to do some further validation on the incoming requests. 

Right now, the flow of traffic is a many-to-one relationship between hosts/VMs running RHEL OS and rhelemeter-server.
In some cases, an intermediate proxy will validate and terminate mTLS and in those cases, the proxy must forward on the client information, as well as a pre-shared key in a set of headers (configurable) like so

```
x-gateway-secret: ${PSK}  //Example PSK -> 46545757575
x-certauth-cn:  ${Certificate Subject}  //Example  Certificate Subject ->  "/O = 12345, /CN = 1234567-9b7c-48f6-8d5b-7654321
```

This change enables us to decode the Subjects CommonName and Organisation in middleware and set it on the context of the request to be dealt with further in the chain of handlers. This is done in such a fashion since we already decode the remote write request as part of the label and metric whitelisting logic. This avoids us having to bare the cost of decoding and wrapping the request again in such fashion with the view of keeping the hot path as optimised as possible, since we piggy-back on the existing parsed time series.

The drawback to this is the slight added complexity but my view is that with an ever growing number of incoming requests expected, this is the preferred option.
