### PR TITLE
MON-3669: Add rule for effective CPU cores for subscription usage purposes

### DIFF
--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -160,6 +160,55 @@
                 sum(sum_over_time(cluster:capacity_cpu_cores:sum{label_node_role_kubernetes_io = ''}[1h:5m])) by (_id) / scalar(count_over_time(vector(1)[1h:5m]))
               |||,
             },
+            {
+              // OpenShift Cluster effective cores for subscription usage.
+              // This counts both worker nodes and, when the control plane is schedulable, control plane nodes.
+              // Only CoreOS nodes are counted.
+              // 1. x86_64 nodes that show hyperthreading in the telemetry have an accurate cores value in node_role_os_version_machine:cpu_capacity_cores:sum.
+              // 2. x86_64 nodes that are do not show hyperthreading and are bare metal have an accurate cores value in node_role_os_version_machine:cpu_capacity_cores:sum.
+              // 3. x86_64 nodes that are do not show hyperthreading and are not bare metal need the cores value adjusted to account for 2 threads per core (* 0.5).
+              // 4. Other CPU architectures are assumed to have accurate values in node_role_os_version_machine:cpu_capacity_cores:sum.
+              record: 'cluster:usage:workload:capacity_effective_cpu_cores',
+              expr: |||
+                # worker ht amd64
+                sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_infra!="true",label_node_role_kubernetes_io_master!="true",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true"}) or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum))
+
+                +
+
+                # worker virt non-ht amd64
+                sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_infra!="true",label_node_role_kubernetes_io_master!="true",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"}) * on(_id) cluster_infrastructure_provider{type!="BareMetal"}) / 2.0 or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum))
+
+                +
+
+                # worker phys non-ht amd64
+                sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_infra!="true",label_node_role_kubernetes_io_master!="true",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"})* on(_id) cluster_infrastructure_provider{type="BareMetal"} or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum))
+
+                +
+
+                # worker non-amd64
+                sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_infra!="true",label_node_role_kubernetes_io_master!="true",label_kubernetes_io_arch!="amd64"}) or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum))
+
+                +
+
+                # schedulable control plane ht amd64
+                sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true"})* on(_id) max by (_id) (cluster_master_schedulable) or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum))
+
+                +
+
+                # schedulable control plane virt non-ht amd64
+                sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"})* on(_id) max by (_id) (cluster_master_schedulable) * on(_id) cluster_infrastructure_provider{type!="BareMetal"}) / 2.0 or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum))
+
+                +
+
+                # schedulable control plane phys non-ht amd64
+                sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"})* on(_id) max by (_id) (cluster_master_schedulable)* on(_id) cluster_infrastructure_provider{type="BareMetal"} or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum))
+
+                +
+
+                # schedulable control plane non-amd64
+                sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_kubernetes_io_arch!="amd64"})* on(_id) max by (_id) (cluster_master_schedulable) or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum))
+              |||,
+            },
           ],
         },
       ],

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -192,7 +192,7 @@
                 +
 
                 # schedulable control plane ht amd64
-                (sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_master="true",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true"}) * on(_id) group by(_id) (cluster_master_schedulable) or cluster:cpu_capacity_cores:_id)
+                (sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_master="true",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true"}) * on(_id) group by(_id) (cluster_master_schedulable == 1) or cluster:cpu_capacity_cores:_id)
 
                 +
 

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -176,7 +176,7 @@
                 +
 
                 # worker virt non-ht amd64
-                ((sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_infra!="true",label_node_role_kubernetes_io_master!="true",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"}) * on(_id) cluster_infrastructure_provider{type!="BareMetal"}) / 2.0 or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
+                ((sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_infra!="true",label_node_role_kubernetes_io_master!="true",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"}) * on(_id) group(cluster_infrastructure_provider{type!="BareMetal"}) by (_id)) / 2.0 or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
 
                 +
 
@@ -196,7 +196,7 @@
                 +
 
                 # schedulable control plane virt non-ht amd64
-                ((sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"})* on(_id) max by (_id) (cluster_master_schedulable) * on(_id) cluster_infrastructure_provider{type!="BareMetal"}) / 2.0 or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
+                ((sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"})* on(_id) max by (_id) (cluster_master_schedulable) * on(_id) group(cluster_infrastructure_provider{type!="BareMetal"}) by (_id)) / 2.0 or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
 
                 +
 

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -164,7 +164,7 @@
               // returns 0 for any cluster reporting core capacity, used to improve performance of cluster:capacity_effective_cpu_cores
               record: 'cluster:cpu_capacity_cores:_id',
               expr: |||
-                group by(_id) (node_role_os_version_machine:cpu_capacity_cores:sum) * 0
+                group by(_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos"}) * 0
               |||,
             },
             {

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -171,42 +171,42 @@
               record: 'cluster:usage:workload:capacity_effective_cpu_cores',
               expr: |||
                 # worker ht amd64
-                sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_infra!="true",label_node_role_kubernetes_io_master!="true",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true"}) or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum))
+                (sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_infra!="true",label_node_role_kubernetes_io_master!="true",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true"}) or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
 
                 +
 
                 # worker virt non-ht amd64
-                sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_infra!="true",label_node_role_kubernetes_io_master!="true",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"}) * on(_id) cluster_infrastructure_provider{type!="BareMetal"}) / 2.0 or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum))
+                ((sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_infra!="true",label_node_role_kubernetes_io_master!="true",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"}) * on(_id) cluster_infrastructure_provider{type!="BareMetal"}) / 2.0 or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
 
                 +
 
                 # worker phys non-ht amd64
-                sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_infra!="true",label_node_role_kubernetes_io_master!="true",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"})* on(_id) cluster_infrastructure_provider{type="BareMetal"} or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum))
+                (sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_infra!="true",label_node_role_kubernetes_io_master!="true",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"})* on(_id) cluster_infrastructure_provider{type="BareMetal"} or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
 
                 +
 
                 # worker non-amd64
-                sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_infra!="true",label_node_role_kubernetes_io_master!="true",label_kubernetes_io_arch!="amd64"}) or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum))
+                (sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_infra!="true",label_node_role_kubernetes_io_master!="true",label_kubernetes_io_arch!="amd64"}) or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
 
                 +
 
                 # schedulable control plane ht amd64
-                sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true"})* on(_id) max by (_id) (cluster_master_schedulable) or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum))
+                (sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true"})* on(_id) max by (_id) (cluster_master_schedulable) or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
 
                 +
 
                 # schedulable control plane virt non-ht amd64
-                sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"})* on(_id) max by (_id) (cluster_master_schedulable) * on(_id) cluster_infrastructure_provider{type!="BareMetal"}) / 2.0 or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum))
+                ((sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"})* on(_id) max by (_id) (cluster_master_schedulable) * on(_id) cluster_infrastructure_provider{type!="BareMetal"}) / 2.0 or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
 
                 +
 
                 # schedulable control plane phys non-ht amd64
-                sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"})* on(_id) max by (_id) (cluster_master_schedulable)* on(_id) cluster_infrastructure_provider{type="BareMetal"} or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum))
+                (sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"})* on(_id) max by (_id) (cluster_master_schedulable)* on(_id) cluster_infrastructure_provider{type="BareMetal"} or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
 
                 +
 
                 # schedulable control plane non-amd64
-                sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_kubernetes_io_arch!="amd64"})* on(_id) max by (_id) (cluster_master_schedulable) or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum))
+                (sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_kubernetes_io_arch!="amd64"})* on(_id) max by (_id) (cluster_master_schedulable) or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
               |||,
             },
           ],

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -191,22 +191,23 @@
                 +
 
                 # schedulable control plane ht amd64
-                (sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true"})* on(_id) max by (_id) (cluster_master_schedulable) or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
+                (sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_master="true",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true"})* on(_id) max by (_id) (cluster_master_schedulable) or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
 
                 +
 
                 # schedulable control plane virt non-ht amd64
-                ((sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"})* on(_id) max by (_id) (cluster_master_schedulable) * on(_id) group(cluster_infrastructure_provider{type!="BareMetal"}) by (_id)) / 2.0 or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
+                ((sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_master="true",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"})* on(_id) max by (_id) (cluster_master_schedulable) * on(_id) group(cluster_infrastructure_provider{type!="BareMetal"}) by (_id)) / 2.0 or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
 
                 +
 
                 # schedulable control plane phys non-ht amd64
-                (sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"})* on(_id) max by (_id) (cluster_master_schedulable)* on(_id) cluster_infrastructure_provider{type="BareMetal"} or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
+                (sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_master="true",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"})* on(_id) max by (_id) (cluster_master_schedulable)* on(_id) cluster_infrastructure_provider{type="BareMetal"} or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
 
                 +
 
                 # schedulable control plane non-amd64
-                (sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_kubernetes_io_arch!="amd64"})* on(_id) max by (_id) (cluster_master_schedulable) or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
+                (sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_master="true",label_kubernetes_io_arch!="amd64"})* on(_id) max by (_id) (cluster_master_schedulable) or (0 * max by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum)))
+
               |||,
             },
           ],

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -197,12 +197,12 @@
                 +
 
                 # schedulable control plane non-ht amd64
-                (sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_master="true",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"}) * on(_id) group by(_id) (cluster_master_schedulable) / 2.0 or cluster:cpu_capacity_cores:_id)
+                (sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_master="true",label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="false"}) * on(_id) group by(_id) (cluster_master_schedulable == 1) / 2.0 or cluster:cpu_capacity_cores:_id)
 
                 +
 
                 # schedulable control plane non-amd64
-                (sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_master="true",label_kubernetes_io_arch!="amd64"}) * on(_id) group by(_id) (cluster_master_schedulable) or cluster:cpu_capacity_cores:_id)
+                (sum by (_id) (node_role_os_version_machine:cpu_capacity_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_master="true",label_kubernetes_io_arch!="amd64"}) * on(_id) group by(_id) (cluster_master_schedulable == 1) or cluster:cpu_capacity_cores:_id)
               |||,
             },
           ],


### PR DESCRIPTION
Red Hat OpenShift Container Platform subscriptions are often measured against underlying cores. However, the metrics for cores are unreliable with some known edge cases. Namely, when virtualization is used, depending on a variety of factors, the hypervisor doesn't report the underlying cores, and instead reports a core per "cpu" where "cpu" is a schedulable executor (possibly backed by a single hyperthreaded executor). In order to address, we assume a ratio of 2-vCPU to 1 core, and divide the "cores" value by 2 to normalize when we detect that hyperthreading information was not reported, when we're on x86-64 CPU architecture.

At this time, x86-64 clusters with HT undetected or turned off are the ones affected.

The rule implementation itself divides the cluster into the following components:

* worker x86-64 nodes having hyperthreading information reported (no adjustment)
* worker x86-64 nodes having no hyperthreading information reported (divide by 2)
* worker nodes with non-x86-64 CPU arch (no adjustment)
* schedulable control plane x86-64 nodes having hyperthreading information reported (no adjustment)
* schedulable control plane x86-64 nodes having no hyperthreading information reported (divide by 2)
* schedulable control plane nodes with non-x86-64 CPU arch (no adjustment)