### PR TITLE
MON-3715: remove obsolete targets from Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ telemeter-bench
 /bin
 /benchmark
 benchmark.pdf
-/docs/telemeter_query
 
 # These are empty target files, created on every docker build. Their sole
 # purpose is to track the last target execution time to evalualte, whether the

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -4,7 +4,6 @@ go 1.14
 
 require (
 	github.com/brancz/gojsontoyaml v0.0.0-20200602132005-3697ded27e8c
-	github.com/campoy/embedmd v1.0.0
 	github.com/google/go-jsonnet v0.16.0
 	github.com/jsonnet-bundler/jsonnet-bundler v0.4.0
 	github.com/observatorium/up v0.0.0-20200615121732-d763595ede50

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 // Package tools tracks dependencies for tools that used in the build process.
@@ -6,7 +7,6 @@ package tools
 
 import (
 	_ "github.com/brancz/gojsontoyaml"
-	_ "github.com/campoy/embedmd"
 	_ "github.com/google/go-jsonnet/cmd/jsonnet"
 	_ "github.com/google/go-jsonnet/cmd/jsonnetfmt"
 	_ "github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb"


### PR DESCRIPTION
The documentation about metrics being forwarded via Telemetry lives in the cluster-monitoring-operator repository.