### PR TITLE
OCPBUGS-24983: Force kill jobs after integration v2 test finish

### DIFF
--- a/test/integration-v2.sh
+++ b/test/integration-v2.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 result=1
-trap 'kill $(jobs -p); exit $result' EXIT
+trap 'kill -9 $(jobs -p); exit $result' EXIT
 
 (./authorization-server localhost:9101 ./test/tokens.json) &
 


### PR DESCRIPTION
Memcached remains stuck with graceful kill

After https://github.com/openshift/telemeter/pull/497 integration test lane is broken and time out is reached. 
Force kill memcached after the execution of test let the lane finish correctly.