### PR TITLE
Add cnv_abnormal recording rule to telemeter

### DIFF
--- a/manifests/benchmark/statefulSetTelemeterServer.yaml
+++ b/manifests/benchmark/statefulSetTelemeterServer.yaml
@@ -48,6 +48,7 @@ spec:
         - --whitelist={__name__="cluster:virt_platform_nodes:sum"}
         - --whitelist={__name__="cluster:node_instance_type_count:sum"}
         - --whitelist={__name__="cnv:vmi_status_running:count"}
+        - --whitelist={__name__="cnv_abnormal"}
         - --whitelist={__name__="node_role_os_version_machine:cpu_capacity_cores:sum"}
         - --whitelist={__name__="node_role_os_version_machine:cpu_capacity_sockets:sum"}
         - --whitelist={__name__="subscription_sync_total"}


### PR DESCRIPTION
Add new recording rule about cnv issues to telemeter, as for now the only issue is memory exceeded.  

This pr need to be merged after https://github.com/kubevirt/kubevirt/pull/11557.