### PR TITLE
OSD-25491,OSD-25492:New recording rules averaging CPU consumption for ROSA HCP & ROSA classic clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ telemeter-bench
 /bin
 /benchmark
 benchmark.pdf
+/tmp
 
 # These are empty target files, created on every docker build. Their sole
 # purpose is to track the last target execution time to evalualte, whether the

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -204,6 +204,15 @@
                 max by (_id, managed_cluster_id) (acm_managed_cluster_worker_cores:max)
               |||,
             },
+            {
+              // Hypershift Cluster vCPU-hours for the last hour.
+              // The divisor of scalar(count_over_time(vector(1)[1h:5m])) allows us to get an effective average value having "absent data" treated as 0.
+              // sum(...) by (_id) is used ensure a single datapoint per cluster ID.
+              record: 'hostedcluster:hypershift_cluster_vcpus:vcpu_hours',
+              expr: |||
+                max by(_id)(sum_over_time(hostedcluster:hypershift_cluster_vcpus:max[1h:5m])) / scalar(count_over_time(vector(1)[1h:5m]))
+              |||,
+            },
           ],
         },
       ],

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -213,6 +213,13 @@
                 max by(_id)(sum_over_time(hostedcluster:hypershift_cluster_vcpus:max[1h:5m])) / scalar(count_over_time(vector(1)[1h:5m]))
               |||,
             },
+            {
+              // ROSA (HCP or classic) Cluster vCPU-hours for the last hour.
+              record: 'rosa:cluster:vcpu_hours',
+              expr: |||
+                hostedcluster:hypershift_cluster_vcpus:vcpu_hours or on (_id) cluster:usage:workload:capacity_virtual_cpu_hours
+              |||,
+            },
           ],
         },
       ],

--- a/test/rulestests.yaml
+++ b/test/rulestests.yaml
@@ -157,3 +157,54 @@ tests:
                   value: 32
                 - labels: 'acm_capacity_effective_cpu_cores{_id="another_hub_cluster",managed_cluster_id="none_ocp_aks"}'
                   value: 32
+    # hostedcluster:hypershift_cluster_vcpus:vcpu_hours tests
+    - interval: 1m
+      input_series:
+          - series: 'hostedcluster:hypershift_cluster_vcpus:max{_id="my-id", _mc_id="my-mc-id", mac_name="my-mc-name", exported_namespace="ocm-some-env-my-id"}'
+            values: '0x90 4x90 0x90'
+      promql_expr_test:
+          - expr: hostedcluster:hypershift_cluster_vcpus:vcpu_hours
+            eval_time: 0
+            exp_samples:
+                - labels: 'hostedcluster:hypershift_cluster_vcpus:vcpu_hours{_id="my-id"}'
+                  value: 0
+          - expr: hostedcluster:hypershift_cluster_vcpus:vcpu_hours
+            eval_time: 60m
+            exp_samples:
+                - labels: 'hostedcluster:hypershift_cluster_vcpus:vcpu_hours{_id="my-id"}'
+                  value: 0
+          - expr: hostedcluster:hypershift_cluster_vcpus:vcpu_hours
+            eval_time: 90m
+            exp_samples:
+                - labels: 'hostedcluster:hypershift_cluster_vcpus:vcpu_hours{_id="my-id"}'
+                  value: 0
+          - expr: hostedcluster:hypershift_cluster_vcpus:vcpu_hours
+            eval_time: 122m
+            exp_samples:
+                - labels: 'hostedcluster:hypershift_cluster_vcpus:vcpu_hours{_id="my-id"}'
+                  value: 2
+          - expr: hostedcluster:hypershift_cluster_vcpus:vcpu_hours
+            eval_time: 152m
+            exp_samples:
+                - labels: 'hostedcluster:hypershift_cluster_vcpus:vcpu_hours{_id="my-id"}'
+                  value: 4
+          - expr: hostedcluster:hypershift_cluster_vcpus:vcpu_hours
+            eval_time: 180m
+            exp_samples:
+                - labels: 'hostedcluster:hypershift_cluster_vcpus:vcpu_hours{_id="my-id"}'
+                  value: 4
+          - expr: hostedcluster:hypershift_cluster_vcpus:vcpu_hours
+            eval_time: 212m
+            exp_samples:
+                - labels: 'hostedcluster:hypershift_cluster_vcpus:vcpu_hours{_id="my-id"}'
+                  value: 2
+          - expr: hostedcluster:hypershift_cluster_vcpus:vcpu_hours
+            eval_time: 242m
+            exp_samples:
+                - labels: 'hostedcluster:hypershift_cluster_vcpus:vcpu_hours{_id="my-id"}'
+                  value: 0
+          - expr: hostedcluster:hypershift_cluster_vcpus:vcpu_hours
+            eval_time: 270m
+            exp_samples:
+                - labels: 'hostedcluster:hypershift_cluster_vcpus:vcpu_hours{_id="my-id"}'
+                  value: 0

--- a/test/rulestests.yaml
+++ b/test/rulestests.yaml
@@ -208,3 +208,23 @@ tests:
             exp_samples:
                 - labels: 'hostedcluster:hypershift_cluster_vcpus:vcpu_hours{_id="my-id"}'
                   value: 0
+    # rosa:cluster:vcpu_hours tests
+    - input_series:
+          - series: 'hostedcluster:hypershift_cluster_vcpus:vcpu_hours{_id="my-rosa-hcp-id"}'
+            values: '32'
+          - series: 'cluster:usage:workload:capacity_virtual_cpu_hours{_id="my-rosa-classic-id"}'
+            values: '70'
+          - series: 'hostedcluster:hypershift_cluster_vcpus:vcpu_hours{_id="my-rosa-idk-id"}'
+            values: '36'
+          - series: 'cluster:usage:workload:capacity_virtual_cpu_hours{_id="my-rosa-idk-id"}'
+            values: '15'
+      promql_expr_test:
+          - expr: rosa:cluster:vcpu_hours
+            eval_time: 0
+            exp_samples:
+                - labels: 'rosa:cluster:vcpu_hours{_id="my-rosa-hcp-id"}'
+                  value: 32
+                - labels: 'rosa:cluster:vcpu_hours{_id="my-rosa-classic-id"}'
+                  value: 70
+                - labels: 'rosa:cluster:vcpu_hours{_id="my-rosa-idk-id"}'
+                  value: 36


### PR DESCRIPTION
Those recording rules will be used for the (new) billing of ROSA

Closes [OSD-25491](https://issues.redhat.com//browse/OSD-25491) and [OSD-25492](https://issues.redhat.com//browse/OSD-25492)