### PR TITLE
SWATCH-3413: Add acm_capacity_effective_cpu_cores:sum recording rule

### DIFF
--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -202,17 +202,17 @@
               // 2. The value for the managed OpenShift clusters and the non-OpenShift clusters comes from the ACM metric acm_managed_cluster_worker_cores:max;
               record: 'acm_capacity_effective_cpu_cores',
               expr: |||
-                  # self managed OpenShift cluster
-                  max by (_id, managed_cluster_id) (acm_managed_cluster_info{product="OpenShift"}) * on(managed_cluster_id) group_left() (
-                      # On one side, the acm_managed_cluster_info metric has the managed_cluster_id label identifiying the managed cluster and the _id label identifying the hub cluster.
-                      # On the other side, the cluster:capacity_effective_cpu_cores metric has the _id label which identifying the managed cluster.
-                      # To join the 2 metrics, we need to add a managed_cluster_id label with the same value as _id to the cluster:capacity_effective_cpu_cores metric.
-                      label_replace(
-                        max by(_id) (cluster:capacity_effective_cpu_cores), "managed_cluster_id", "$1", "_id", "(.*)"
-                      )
-                    ) * 2 or
-                  # managed OpenShift cluster and non-OpenShift clusters
-                  max by (_id, managed_cluster_id) (acm_managed_cluster_worker_cores:max)
+                # self managed OpenShift cluster
+                max by (_id, managed_cluster_id) (acm_managed_cluster_info{product="OpenShift"}) * on(managed_cluster_id) group_left() (
+                    # On one side, the acm_managed_cluster_info metric has the managed_cluster_id label identifiying the managed cluster and the _id label identifying the hub cluster.
+                    # On the other side, the cluster:capacity_effective_cpu_cores metric has the _id label which identifying the managed cluster.
+                    # To join the 2 metrics, we need to add a managed_cluster_id label with the same value as _id to the cluster:capacity_effective_cpu_cores metric.
+                    label_replace(
+                      max by(_id) (cluster:capacity_effective_cpu_cores), "managed_cluster_id", "$1", "_id", "(.*)"
+                    )
+                  ) * 2 or
+                # managed OpenShift cluster and non-OpenShift clusters
+                max by (_id, managed_cluster_id) (acm_managed_cluster_worker_cores:max)
               |||,
             },
             {

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -197,13 +197,6 @@
               |||,
             },
             {
-              // Aggregate managed nodes under the cluster so swatch can associate the capacity with the cluster's billing account information
-              record: 'acm_capacity_effective_cpu_cores:sum',
-              expr: |||
-                sum by (_id) (acm_capacity_effective_cpu_cores)
-              |||,
-            },
-            {
               // ACM managed cluster effective cores for subscription usage. It is measured in virtual CPU cores.
               // 1. The value for the self managed OpenShift clusters is derived from the OpenShift metric cluster:capacity_effective_cpu_cores and is normalized to virtual CPU cores (* 2);
               // 2. The value for the managed OpenShift clusters and the non-OpenShift clusters comes from the ACM metric acm_managed_cluster_worker_cores:max;
@@ -220,6 +213,13 @@
                     ) * 2 or
                   # managed OpenShift cluster and non-OpenShift clusters
                   max by (_id, managed_cluster_id) (acm_managed_cluster_worker_cores:max)
+              |||,
+            },
+            {
+              // Aggregate managed nodes under the cluster so swatch can associate the capacity with the cluster's billing account information
+              record: 'acm_capacity_effective_cpu_cores:sum',
+              expr: |||
+                sum by (_id) (acm_capacity_effective_cpu_cores)
               |||,
             },
             {

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -197,22 +197,29 @@
               |||,
             },
             {
+              // Aggregate managed nodes under the cluster so swatch can associate the capacity with the cluster's billing account information
+              record: 'acm_capacity_effective_cpu_cores:sum',
+              expr: |||
+                sum by (_id) (acm_capacity_effective_cpu_cores)
+              |||,
+            },
+            {
               // ACM managed cluster effective cores for subscription usage. It is measured in virtual CPU cores.
               // 1. The value for the self managed OpenShift clusters is derived from the OpenShift metric cluster:capacity_effective_cpu_cores and is normalized to virtual CPU cores (* 2);
               // 2. The value for the managed OpenShift clusters and the non-OpenShift clusters comes from the ACM metric acm_managed_cluster_worker_cores:max;
               record: 'acm_capacity_effective_cpu_cores',
               expr: |||
-                # self managed OpenShift cluster
-                max by (_id, managed_cluster_id) (acm_managed_cluster_info{product="OpenShift"}) * on(managed_cluster_id) group_left() (
-                    # On one side, the acm_managed_cluster_info metric has the managed_cluster_id label identifiying the managed cluster and the _id label identifying the hub cluster.
-                    # On the other side, the cluster:capacity_effective_cpu_cores metric has the _id label which identifying the managed cluster.
-                    # To join the 2 metrics, we need to add a managed_cluster_id label with the same value as _id to the cluster:capacity_effective_cpu_cores metric.
-                    label_replace(
-                      max by(_id) (cluster:capacity_effective_cpu_cores), "managed_cluster_id", "$1", "_id", "(.*)"
-                    )
-                  ) * 2 or
-                # managed OpenShift cluster and non-OpenShift clusters
-                max by (_id, managed_cluster_id) (acm_managed_cluster_worker_cores:max)
+                  # self managed OpenShift cluster
+                  max by (_id, managed_cluster_id) (acm_managed_cluster_info{product="OpenShift"}) * on(managed_cluster_id) group_left() (
+                      # On one side, the acm_managed_cluster_info metric has the managed_cluster_id label identifiying the managed cluster and the _id label identifying the hub cluster.
+                      # On the other side, the cluster:capacity_effective_cpu_cores metric has the _id label which identifying the managed cluster.
+                      # To join the 2 metrics, we need to add a managed_cluster_id label with the same value as _id to the cluster:capacity_effective_cpu_cores metric.
+                      label_replace(
+                        max by(_id) (cluster:capacity_effective_cpu_cores), "managed_cluster_id", "$1", "_id", "(.*)"
+                      )
+                    ) * 2 or
+                  # managed OpenShift cluster and non-OpenShift clusters
+                  max by (_id, managed_cluster_id) (acm_managed_cluster_worker_cores:max)
               |||,
             },
             {

--- a/test/rulestests.yaml
+++ b/test/rulestests.yaml
@@ -157,6 +157,32 @@ tests:
                   value: 32
                 - labels: 'acm_capacity_effective_cpu_cores{_id="another_hub_cluster",managed_cluster_id="none_ocp_aks"}'
                   value: 32
+    # acm_capacity_effective_cpu_cores:sum tests
+    - input_series:
+          # worker nodes only
+          - series: 'acm_capacity_effective_cpu_cores{_id="hub_cluster0", managed_cluster_id="managed_cluster_id0"}'
+            values: '10'
+          - series: 'acm_capacity_effective_cpu_cores{_id="hub_cluster0", managed_cluster_id="managed_cluster_id00"}'
+            values: '10'
+          - series: 'acm_capacity_effective_cpu_cores{_id="hub_cluster0", managed_cluster_id="managed_cluster_id000"}'
+            values: '10'
+          # worker nodes plus hub
+          - series: 'acm_capacity_effective_cpu_cores{_id="hub_cluster1", managed_cluster_id="hub_cluster1"}'
+            values: '5'
+          - series: 'acm_capacity_effective_cpu_cores{_id="hub_cluster1", managed_cluster_id="managed_cluster_id1"}'
+            values: '10'
+          - series: 'acm_capacity_effective_cpu_cores{_id="hub_cluster1", managed_cluster_id="managed_cluster_id11"}'
+            values: '10'
+      promql_expr_test:
+          - expr: acm_capacity_effective_cpu_cores:sum
+            eval_time: 0
+            exp_samples:
+                # worker nodes only
+                - labels: 'acm_capacity_effective_cpu_cores:sum{_id="hub_cluster0"}'
+                  value: 30
+                # worker nodes plus hub
+                - labels: 'acm_capacity_effective_cpu_cores:sum{_id="hub_cluster1"}'
+                  value: 25
     # hostedcluster:hypershift_cluster_vcpus:vcpu_hours tests
     - interval: 1m
       input_series:


### PR DESCRIPTION
A recording rule needs to aggregate worker nodes under the hub cluster so swatch can associate the metric with the hub's billing account information.

Create a new recording rule that uses the existing one, and adds the "sum" logic on top of it.