### PR TITLE
OCPBUGS-50837: Check nil metric in elide label

### DIFF
--- a/pkg/metricfamily/elide.go
+++ b/pkg/metricfamily/elide.go
@@ -26,6 +26,10 @@ func (t *elide) Transform(family *prom.MetricFamily) (bool, error) {
 	}
 
 	for i := range family.Metric {
+		if family.Metric[i] == nil {
+			continue
+		}
+
 		var filtered []*prom.LabelPair
 		for j := range family.Metric[i].Label {
 			if _, elide := t.labelSet[family.Metric[i].Label[j].GetName()]; elide {


### PR DESCRIPTION
We came across this case when dealing with a metric sent by telemeter-client that was not in the allowlist.

The whitelister sets the metric as nil, and as elide is the transformer right after whitelister, it comes across the nil metric and panics as a result.