### PR TITLE
SREP-3493: add `cluster:usage:control_plane:instance_hours`

### DIFF
--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -158,22 +158,14 @@
               |||,
             },
             {
-              // OpenShift Control Plane instance hours over the past hour.
-              // This recording rule represents the instance hours over the past hour in which the control plane has been active.
-              // This recording rule is based on two metrics:
-              // 1) `cluster:usage:workload:capacity_physical_cpu_cores:max:5m` which is used as an anchor for the control plane hours in non-HCP clusters.
-              // 2) `hostedcluster:hypershift_cluster_vcpus:max` which is used as an anchor for the control plane hours in HCP clusters.
-              // While these metrics relate to the actual worker count, they are emitted by either infrastructure nodes for non-HCP clusters, 
-              // or the management cluster layer for HCP clusters and at least 1 time series is expected at any point in time during the cluster's lifetime.
-              // 
-              // Note for HCP: 
-              // While for HCP both metrics may be emitted to telemetry (one from the telemeter-client, one from the management cluster), 
-              // this is not always the case, as the telemeter-client is optional or may not be reliable because it runs on the worker nodes.
-              // We fall back to the more reliable metric emitted from the management cluster in any case. 
+              // OpenShift Cluster Instance-hours for the last hour.
               record: 'cluster:usage:workload:capacity_physical_instance_hours',
               expr: |||
                 max by(_id) (count_over_time(cluster:usage:workload:capacity_physical_cpu_cores:max:5m[1h:5m])) / scalar(steps:count1h)
                 or
+                // ROSA HCP Control Plane instance hours. 
+                // Note: Management clusters emit worker vCPU metrics while the control plane is active; 
+                // we use these as the authoritative base for calculating control plane vCPU hours.
                 max by(_id) (count_over_time((hostedcluster:hypershift_cluster_vcpus:max > 0)[1h:5m])) / scalar(steps:count1h)
               |||,
             },

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -163,13 +163,13 @@
               // This recording rule is based on two metrics:
               // 1) `cluster:usage:workload:capacity_physical_cpu_cores:max:5m` which is used as an anchor for the control plane hours in non-HCP clusters.
               // 2) `hostedcluster:hypershift_cluster_vcpus:max` which is used as an anchor for the control plane hours in HCP clusters.
-              // While these metrics relate to the actual worker count, they are emitted by either infrastructure nodes for non-HCP clusters,
+              // While these metrics relate to the actual worker count, they are emitted by either infrastructure nodes for non-HCP clusters, 
               // or the management cluster layer for HCP clusters and at least 1 time series is expected at any point in time during the cluster's lifetime.
-              //
-              // Note for HCP:
-              // While for HCP both metrics may be emitted to telemetry (one from the telemeter-client, one from the management cluster),
+              // 
+              // Note for HCP: 
+              // While for HCP both metrics may be emitted to telemetry (one from the telemeter-client, one from the management cluster), 
               // this is not always the case, as the telemeter-client is optional or may not be reliable because it runs on the worker nodes.
-              // We fall back to the more reliable metric emitted from the management cluster in any case.
+              // We fall back to the more reliable metric emitted from the management cluster in any case. 
               record: 'cluster:usage:workload:capacity_physical_instance_hours',
               expr: |||
                 max by(_id) (count_over_time(cluster:usage:workload:capacity_physical_cpu_cores:max:5m[1h:5m])) / scalar(steps:count1h)

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -166,7 +166,7 @@
                 // ROSA HCP Control Plane instance hours. 
                 // Note: Management clusters emit worker vCPU metrics while the control plane is active; 
                 // we use these as the authoritative base for calculating control plane vCPU hours.
-                max by(_id) (count_over_time((hostedcluster:hypershift_cluster_vcpus:max > 0)[1h:5m])) / scalar(steps:count1h)
+                max by(_id) (count_over_time((rosa:cluster:vcpu_hours > 0)[1h:5m])) / scalar(steps:count1h)
               |||,
             },
             {

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -162,11 +162,6 @@
               record: 'cluster:usage:workload:capacity_physical_instance_hours',
               expr: |||
                 max by(_id) (count_over_time(cluster:usage:workload:capacity_physical_cpu_cores:max:5m[1h:5m])) / scalar(steps:count1h)
-                or
-                // ROSA HCP Control Plane instance hours. 
-                // Note: Management clusters emit worker vCPU metrics while the control plane is active; 
-                // we use these as the authoritative base for calculating control plane vCPU hours.
-                max by(_id) (count_over_time((rosa:cluster:vcpu_hours > 0)[1h:5m])) / scalar(steps:count1h)
               |||,
             },
             {

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -165,6 +165,26 @@
               |||,
             },
             {
+              // OpenShift Control Plane instance hours over the past hour.
+              // This recording rule represents the instance hours over the past hour in which the control plane has been active.
+              // This recording rule is based on two metrics:
+              // 1) `cluster:usage:workload:capacity_physical_cpu_cores:max:5m` which is used as an anchor for the control plane hours in non-HCP clusters.
+              // 2) `hostedcluster:hypershift_cluster_vcpus:max` which is used as an anchor for the control plane hours in HCP clusters.
+              // While these metrics relate to the actual worker count, they are emitted by either infrastructure nodes for non-HCP clusters,
+              // or the management cluster layer for HCP clusters and at least 1 time series is expected at any point in time during the cluster's lifetime.
+              //
+              // Note for HCP:
+              // While for HCP both metrics may be emitted to telemetry (one from the telemeter-client, one from the management cluster),
+              // this is not always the case, as the telemeter-client is optional or may not be reliable because it runs on the worker nodes.
+              // We fall back to the more reliable metric emitted from the management cluster in any case.
+              record: 'cluster:usage:control_plane:instance_hours',
+              expr: |||
+                cluster:usage:workload:capacity_physical_instance_hours
+                or
+                max by(_id) (count_over_time((hostedcluster:hypershift_cluster_vcpus:max > 0)[1h:5m])) / scalar(steps:count1h)
+              |||,
+            },
+            {
               // OpenShift Cluster vCPU-hours for the last hour.
               record: 'cluster:usage:workload:capacity_virtual_cpu_hours',
               expr: |||

--- a/test/rulestests.yaml
+++ b/test/rulestests.yaml
@@ -234,6 +234,41 @@ tests:
             exp_samples:
                 - labels: 'hostedcluster:hypershift_cluster_vcpus:vcpu_hours{_id="my-id"}'
                   value: 0
+    # cluster:usage:control_plane:instance_hours tests
+    # HCP cluster where data plane is down: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
+    # is not reported, but hostedcluster:hypershift_cluster_vcpus:max is reported from RH infrastructure
+    - input_series:
+          - series: 'hostedcluster:hypershift_cluster_vcpus:max{_id="hcp-data-plane-down"}'
+            values: '0x90 4x90 0x90'
+      promql_expr_test:
+          # Before the control plane becomes active: no samples
+          - expr: cluster:usage:control_plane:instance_hours{_id="hcp-data-plane-down"}
+            eval_time: 60m
+            exp_samples: []
+          # Active for 30 min over the last hour
+          - expr: cluster:usage:control_plane:instance_hours{_id="hcp-data-plane-down"}
+            eval_time: 122m
+            exp_samples:
+                - labels: 'cluster:usage:control_plane:instance_hours{_id="hcp-data-plane-down"}'
+                  value: 0.5
+          # Active for the full hour
+          - expr: cluster:usage:control_plane:instance_hours{_id="hcp-data-plane-down"}
+            eval_time: 152m
+            exp_samples:
+                - labels: 'cluster:usage:control_plane:instance_hours{_id="hcp-data-plane-down"}'
+                  value: 1
+    # Backwards compatibility: both metrics present, non-HCP expression takes precedence via or
+    - input_series:
+          - series: 'cluster:usage:workload:capacity_physical_cpu_cores:max:5m{_id="both"}'
+            values: '4x180'
+          - series: 'hostedcluster:hypershift_cluster_vcpus:max{_id="both"}'
+            values: '0x180'
+      promql_expr_test:
+          - expr: cluster:usage:control_plane:instance_hours{_id="both"}
+            eval_time: 60m
+            exp_samples:
+                - labels: 'cluster:usage:control_plane:instance_hours{_id="both"}'
+                  value: 1
     # rosa:cluster:vcpu_hours tests
     - input_series:
           - series: 'hostedcluster:hypershift_cluster_vcpus:vcpu_hours{_id="my-rosa-hcp-id"}'


### PR DESCRIPTION
This PR reverts changes to `cluster:usage:workload:capacity_physical_instance_hours` from https://github.com/openshift/telemeter/pull/577 and moves our changes to a new recording rule `cluster:usage:control_plane:instance_hours`.
