### PR TITLE
SREP-3493: deduplicate cluster:usage:control_plane:instance_hours output series

### DIFF
--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -179,11 +179,9 @@
               // We fall back to the more reliable metric emitted from the management cluster in any case.
               record: 'cluster:usage:control_plane:instance_hours',
               expr: |||
-                max by (_id) (
-                  cluster:usage:workload:capacity_physical_instance_hours
-                  or
-                  max by(_id) (count_over_time((hostedcluster:hypershift_cluster_vcpus:max > 0)[1h:5m])) / scalar(steps:count1h)
-                )
+                max by (_id) (cluster:usage:workload:capacity_physical_instance_hours)
+                or
+                max by(_id) (count_over_time((hostedcluster:hypershift_cluster_vcpus:max > 0)[1h:5m])) / scalar(steps:count1h)
               |||,
             },
             {

--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -179,9 +179,11 @@
               // We fall back to the more reliable metric emitted from the management cluster in any case.
               record: 'cluster:usage:control_plane:instance_hours',
               expr: |||
-                cluster:usage:workload:capacity_physical_instance_hours
-                or
-                max by(_id) (count_over_time((hostedcluster:hypershift_cluster_vcpus:max > 0)[1h:5m])) / scalar(steps:count1h)
+                max by (_id) (
+                  cluster:usage:workload:capacity_physical_instance_hours
+                  or
+                  max by(_id) (count_over_time((hostedcluster:hypershift_cluster_vcpus:max > 0)[1h:5m])) / scalar(steps:count1h)
+                )
               |||,
             },
             {

--- a/test/rulestests.yaml
+++ b/test/rulestests.yaml
@@ -238,7 +238,7 @@ tests:
     # HCP cluster where data plane is down: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
     # is not reported, but hostedcluster:hypershift_cluster_vcpus:max is reported from RH infrastructure
     - input_series:
-          - series: 'hostedcluster:hypershift_cluster_vcpus:max{_id="hcp-data-plane-down"}'
+          - series: 'hostedcluster:hypershift_cluster_vcpus:max{_id="hcp-data-plane-down", tenant_id="test"}'
             values: '0x90 4x90 0x90'
       promql_expr_test:
           # Before the control plane becomes active: no samples
@@ -259,9 +259,9 @@ tests:
                   value: 1
     # Backwards compatibility: both metrics present, non-HCP expression takes precedence via or
     - input_series:
-          - series: 'cluster:usage:workload:capacity_physical_cpu_cores:max:5m{_id="both"}'
+          - series: 'cluster:usage:workload:capacity_physical_cpu_cores:max:5m{_id="both", tenant_id="test"}'
             values: '4x180'
-          - series: 'hostedcluster:hypershift_cluster_vcpus:max{_id="both"}'
+          - series: 'hostedcluster:hypershift_cluster_vcpus:max{_id="both", tenant_id="test"}'
             values: '0x180'
       promql_expr_test:
           - expr: cluster:usage:control_plane:instance_hours{_id="both"}


### PR DESCRIPTION
This PR fixes the `cluster:usage:control_plane:instance_hours` recording rule to not attempt and emit duplicate time series.

The `or` can result in two series found by `_id`, which would result in the recording rule creating duplicate time series, which is not allowed.

It's unclear to me why the unit tests didn't catch this, but on staging telemeter we get the following issue: `vector contains metrics with the same labelset after applying rule labels`. 
