### PR TITLE
OCPBUGS-79699: rules: add rhel to label_node_openshift_io_os_id

### DIFF
--- a/jsonnet/telemeter/rules.libsonnet
+++ b/jsonnet/telemeter/rules.libsonnet
@@ -202,25 +202,25 @@
               // returns 0 for any cluster reporting core capacity, used to improve performance of cluster:capacity_effective_cpu_cores
               record: 'cluster:cpu_capacity_cores:_id',
               expr: |||
-                group by(_id, tenant_id) (cluster:capacity_cpu_cores:sum{label_node_openshift_io_os_id="rhcos"}) * 0
+                group by(_id, tenant_id) (cluster:capacity_cpu_cores:sum{label_node_openshift_io_os_id=~"rhcos|rhel"}) * 0
               |||,
             },
             {
               // OpenShift Cluster effective cores for subscription usage.
               // This counts both worker nodes and, when the control plane is schedulable, control plane nodes.
-              // Only CoreOS nodes are counted.
+              // Only CoreOS nodes are counted (label_node_openshift_io_os_id rhcos on 4.18 and earlier, rhel on 4.19+).
               // 1. x86_64 nodes need the cores value adjusted to account for 2 threads per core (* 0.5).
               // 2. Other CPU architectures are assumed to have accurate values in cluster:capacity_cpu_cores:sum.
               record: 'cluster:capacity_effective_cpu_cores',
               expr: |||
                 # worker amd64
-                (sum by (_id, tenant_id) (cluster:capacity_cpu_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io!="master",label_node_role_kubernetes_io!="infra",label_kubernetes_io_arch="amd64"}) / 2.0 or cluster:cpu_capacity_cores:_id) +
+                (sum by (_id, tenant_id) (cluster:capacity_cpu_cores:sum{label_node_openshift_io_os_id=~"rhcos|rhel",label_node_role_kubernetes_io!="master",label_node_role_kubernetes_io!="infra",label_kubernetes_io_arch="amd64"}) / 2.0 or cluster:cpu_capacity_cores:_id) +
                 # worker non-amd64
-                (sum by (_id, tenant_id) (cluster:capacity_cpu_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io!="master",label_node_role_kubernetes_io!="infra",label_kubernetes_io_arch!="amd64"}) or cluster:cpu_capacity_cores:_id) +
+                (sum by (_id, tenant_id) (cluster:capacity_cpu_cores:sum{label_node_openshift_io_os_id=~"rhcos|rhel",label_node_role_kubernetes_io!="master",label_node_role_kubernetes_io!="infra",label_kubernetes_io_arch!="amd64"}) or cluster:cpu_capacity_cores:_id) +
                 # schedulable control plane amd64
-                (sum by (_id, tenant_id) (cluster:capacity_cpu_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io="master",label_kubernetes_io_arch="amd64"}) * on(_id, tenant_id) group by(_id, tenant_id) (cluster_master_schedulable == 1) / 2.0 or cluster:cpu_capacity_cores:_id) +
+                (sum by (_id, tenant_id) (cluster:capacity_cpu_cores:sum{label_node_openshift_io_os_id=~"rhcos|rhel",label_node_role_kubernetes_io="master",label_kubernetes_io_arch="amd64"}) * on(_id, tenant_id) group by(_id, tenant_id) (cluster_master_schedulable == 1) / 2.0 or cluster:cpu_capacity_cores:_id) +
                 # schedulable control plane non-amd64
-                (sum by (_id, tenant_id) (cluster:capacity_cpu_cores:sum{label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io="master",label_kubernetes_io_arch!="amd64"}) * on(_id, tenant_id) group by(_id, tenant_id) (cluster_master_schedulable == 1) or cluster:cpu_capacity_cores:_id)
+                (sum by (_id, tenant_id) (cluster:capacity_cpu_cores:sum{label_node_openshift_io_os_id=~"rhcos|rhel",label_node_role_kubernetes_io="master",label_kubernetes_io_arch!="amd64"}) * on(_id, tenant_id) group by(_id, tenant_id) (cluster_master_schedulable == 1) or cluster:cpu_capacity_cores:_id)
               |||,
             },
             {

--- a/test/rulestests.yaml
+++ b/test/rulestests.yaml
@@ -91,6 +91,16 @@ tests:
             exp_samples:
                 - labels: 'cluster:capacity_effective_cpu_cores{_id="non-amd64_infra",tenant_id="tenant_id"}'
                   value: 0
+    # cluster:capacity_effective_cpu_cores — 4.19+ nodes expose label_node_openshift_io_os_id=rhel (still CoreOS)
+    - input_series:
+          - series: 'cluster:capacity_cpu_cores:sum{label_node_openshift_io_os_id="rhel",label_kubernetes_io_arch="amd64",_id="rhel_amd64_worker",tenant_id="tenant_id"}'
+            values: '8'
+      promql_expr_test:
+          - expr: cluster:capacity_effective_cpu_cores{_id="rhel_amd64_worker"}
+            eval_time: 0
+            exp_samples:
+                - labels: 'cluster:capacity_effective_cpu_cores{_id="rhel_amd64_worker",tenant_id="tenant_id"}'
+                  value: 4
     # acm_capacity_effective_cpu_cores tests
     - input_series:
           # self-managed OpenShift cluster


### PR DESCRIPTION
4.19+ reports label_node_openshift_io_os_id=rhel while remaining CoreOS;
the previous rhcos-only selector dropped cluster:capacity_effective_cpu_cores
from telemetry. This commit adds rhel to the rule and a test case.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>