### PR TITLE
Fix for OCPBUGS-88583: CVE-2026-42154

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -26,6 +26,9 @@ const forwardTimeout = 5 * time.Second
 // DefaultRequestLimit is the size limit of a request body coming in
 const DefaultRequestLimit = 128 * 1024
 
+// MaxDecodedBodySize is the maximum allowed size of a decoded snappy request body (10 MB).
+const MaxDecodedBodySize = 10 * 1024 * 1024
+
 // ClusterAuthorizer authorizes a cluster by its token and id, returning a subject or error
 type ClusterAuthorizer interface {
 	AuthorizeCluster(token, cluster string) (subject string, err error)
@@ -182,6 +185,18 @@ func ValidateLabels(logger log.Logger, next http.Handler, labels ...string) http
 		// Set body to this buffer for other handlers to read
 		r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
 
+		decodedLen, err := snappy.DecodedLen(body)
+		if err != nil {
+			level.Warn(logger).Log("msg", "invalid snappy-encoded request body", "err", err)
+			http.Error(w, "invalid snappy-encoded request body", http.StatusBadRequest)
+			return
+		}
+		if decodedLen > MaxDecodedBodySize {
+			level.Warn(logger).Log("msg", "decoded request body too large", "decoded_size", decodedLen, "max_size", MaxDecodedBodySize)
+			http.Error(w, "decoded request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+
 		content, err := snappy.Decode(nil, body)
 		if err != nil {
 			level.Warn(logger).Log("msg", "failed to decode request body", "err", err)
@@ -231,6 +246,18 @@ func (h *Handler) TransformWriteRequest(logger log.Logger, next http.Handler) ht
 		if err != nil {
 			level.Error(logger).Log("msg", "failed to read body", "err", err)
 			http.Error(w, "failed to read body", http.StatusInternalServerError)
+			return
+		}
+
+		decodedLen, err := snappy.DecodedLen(body)
+		if err != nil {
+			level.Warn(logger).Log("msg", "invalid snappy-encoded request body", "err", err)
+			http.Error(w, "invalid snappy-encoded request body", http.StatusBadRequest)
+			return
+		}
+		if decodedLen > MaxDecodedBodySize {
+			level.Warn(logger).Log("msg", "decoded request body too large", "decoded_size", decodedLen, "max_size", MaxDecodedBodySize)
+			http.Error(w, "decoded request body too large", http.StatusRequestEntityTooLarge)
 			return
 		}
 


### PR DESCRIPTION
## Summary
- Fixes CVE-2026-42154: Unauthenticated Denial of Service via Snappy Bomb
- Adds `snappy.DecodedLen` validation before `snappy.Decode` in `ValidateLabels` and `TransformWriteRequest` to reject requests with inflated declared decoded sizes
- Introduces a `MaxDecodedBodySize` constant (10 MB) to cap the decoded payload size

## Test plan
- [ ] Verify the fix compiles cleanly
- [ ] Verify normal remote-write requests continue to work
- [ ] Verify crafted Snappy payloads with inflated decoded-length headers are rejected with 413

🤖 Generated with [Claude Code](https://claude.com/claude-code)